### PR TITLE
docs: remove charter and project-board references from README and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Feature and fix PRs do **not** edit `CHANGELOG.md`. The release-cut PR aggregate
 
 ## Scope discipline
 
-setup-gmat's scope is deliberately narrow: install GMAT and prove `gmatpy` imports. Mission running, output parsing, and astrodynamics validation belong in sibling projects (`gmat-run`, `astro-validate`). Before opening a feature issue, check the [charter](https://github.com/astro-tools/setup-gmat) and existing issues to make sure the work belongs here.
+setup-gmat's scope is deliberately narrow: install GMAT and prove `gmatpy` imports. Mission running, output parsing, and astrodynamics validation belong in sibling projects (`gmat-run`, `astro-validate`). Before opening a feature issue, check existing issues to make sure the work belongs here.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker run --rm -it ghcr.io/astro-tools/gmat:R2026a python -c "import gmatpy"
 
 ## Status
 
-Under active development. The v0.1 install path is not implemented yet — invoking the action today fails with an explicit "not implemented" message. Track progress in the [setup-gmat development project](https://github.com/orgs/astro-tools/projects/5).
+Under active development. The v0.1 install path is not implemented yet — invoking the action today fails with an explicit "not implemented" message.
 
 ## What it does (planned)
 
@@ -36,8 +36,6 @@ Under active development. The v0.1 install path is not implemented yet — invok
 | v0.2       | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
 | v0.3       | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
 | v1.0       | Public API stability; at least two external consumers shipped on the action. |
-
-See the project [charter](https://github.com/astro-tools/setup-gmat/blob/main/docs/charter.md) for the longer-form scope and acceptance criteria. _(Charter source lives in `files/projects/setup-gmat-charter.docx` for now and will be ported to docs in a follow-up.)_
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ docker run --rm -it ghcr.io/astro-tools/gmat:R2026a python -c "import gmatpy"
 
 ## Status
 
-setup-gmat is under active development. The action is not yet usable; see the [project board](https://github.com/orgs/astro-tools/projects/5) for v0.1 progress.
+setup-gmat is under active development. The action is not yet usable.


### PR DESCRIPTION
## Summary

- Drop the link to the org project board (`/projects/5`) from `README.md` and `docs/index.md`; the Status sections keep their "under active development" framing without pointing at internal trackers.
- Remove the dead charter link from `README.md` (`docs/charter.md` does not exist) and the parenthetical about a `.docx` source.
- Remove the charter mention from `CONTRIBUTING.md`'s _Scope discipline_ section so contributors aren't sent to a non-existent doc.

The remaining "project board advances the card to Done" line in `CONTRIBUTING.md` is left as-is — it's a no-link process detail, outside this issue's scope. Issue #9 will handle the broader v0.1-finalization README rewrite later.

## Test plan

- [x] `npm run format:check` passes locally.
- [x] `npm run lint` passes locally.
- [x] CI green on this PR.
- [x] Manual scan of rendered README/docs after merge confirms no orphaned links remain.

Closes #2