### PR TITLE
Add Linux installer download with size sanity check

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,44 @@
+import { stat } from 'node:fs/promises';
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+import type { GmatVersion } from './inputs';
+
+const MIB = 1024 * 1024;
+
+const MIN_SIZE_BYTES: Record<GmatVersion, number> = {
+  R2026a: 380 * MIB,
+};
+
+export async function download(version: GmatVersion): Promise<string> {
+  const url = linuxInstallerUrl(version);
+  core.info(`Downloading GMAT ${version} Linux installer from ${url}`);
+  const archivePath = await tc.downloadTool(url);
+  core.info(`Downloaded to ${archivePath}`);
+  await assertMinSize(archivePath, version, url);
+  return archivePath;
+}
+
+function linuxInstallerUrl(version: GmatVersion): string {
+  return `https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${version}/gmat-ubuntu-x64-${version}.tar.gz/download`;
+}
+
+async function assertMinSize(
+  archivePath: string,
+  version: GmatVersion,
+  url: string,
+): Promise<void> {
+  const minBytes = MIN_SIZE_BYTES[version];
+  const { size } = await stat(archivePath);
+  if (size < minBytes) {
+    throw new Error(
+      `GMAT ${version} installer download appears truncated. ` +
+        `Observed ${formatMiB(size)} (${size} bytes), expected at least ${formatMiB(minBytes)}. ` +
+        `URL: ${url}`,
+    );
+  }
+  core.debug(`Installer size ${formatMiB(size)} passes ${formatMiB(minBytes)} threshold`);
+}
+
+function formatMiB(bytes: number): string {
+  return `${(bytes / MIB).toFixed(1)} MiB`;
+}


### PR DESCRIPTION
## Summary

- New `src/download.ts` exporting `download(version)` that resolves the SourceForge URL for a GMAT release and fetches it via `@actions/tool-cache`'s `downloadTool` (3-attempt retry with backoff, retries on pipeline failures — covers SourceForge's mid-stream drops without a custom wrapper).
- Post-download size check against a per-version table (380 MiB for R2026a) to catch silently truncated downloads that pass HTTP-level checks. The threshold is a `Record<GmatVersion, number>` so new releases are a one-line addition.
- Not yet wired into `install.ts`; extract / api-startup / smoke land in their own issues per the v0.1 charter sequence. `dist/index.js` is unchanged because the new module is not yet reachable from `main.ts` (ncc tree-shakes it).

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (no `dist/` diff, as expected)
- [ ] End-to-end fetch against SourceForge — deferred to the action's self-CI matrix once the install path is wired up; not exercisable from this PR alone.

Closes #5