### PR TITLE
Extract Linux installer and resolve GMAT_ROOT

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,0 +1,49 @@
+import { existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as tc from '@actions/tool-cache';
+
+const API_STARTUP_FILE = path.join('api', 'BuildApiStartupFile.py');
+
+export async function extract(archivePath: string): Promise<string> {
+  core.info(`Extracting GMAT installer ${archivePath}`);
+  const stagingDir = await tc.extractTar(archivePath);
+  core.debug(`Extracted to ${stagingDir}`);
+
+  const stagedRoot = await locateGmatRoot(stagingDir);
+  core.debug(`Resolved staged GMAT_ROOT: ${stagedRoot}`);
+
+  const finalRoot = path.join(runnerTemp(), 'gmat');
+  if (existsSync(finalRoot)) {
+    core.debug(`Removing existing ${finalRoot} before move`);
+    await io.rmRF(finalRoot);
+  }
+  await io.mv(stagedRoot, finalRoot);
+  core.info(`GMAT_ROOT: ${finalRoot}`);
+  return finalRoot;
+}
+
+async function locateGmatRoot(stagingDir: string): Promise<string> {
+  if (existsSync(path.join(stagingDir, API_STARTUP_FILE))) {
+    return stagingDir;
+  }
+  const entries = await readdir(stagingDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(stagingDir, entry.name);
+    if (existsSync(path.join(candidate, API_STARTUP_FILE))) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `Could not locate ${API_STARTUP_FILE} under ${stagingDir}. ` +
+      `The installer archive layout may have changed.`,
+  );
+}
+
+function runnerTemp(): string {
+  return process.env.RUNNER_TEMP ?? os.tmpdir();
+}


### PR DESCRIPTION
## Summary

- New `src/extract.ts` exporting `extract(archivePath)` that unpacks the GMAT tarball with `@actions/tool-cache`'s `extractTar`, locates `api/BuildApiStartupFile.py` via a shallow search (staging root plus its top-level subdirectories — GMAT ships a single top-level dir), and returns its grandparent as the resolved GMAT root.
- Resolved root is moved to `${RUNNER_TEMP}/gmat` before returning, so subsequent steps run in-place. `BuildApiStartupFile.py` is path-sensitive — running it pre-move bakes stale absolute paths into `api_startup_file.txt` and the failure mode is silent at install time but cryptic at `gmatpy` import time.
- Not yet wired into `install.ts`; api-startup and smoke land in their own issues per the v0.1 charter sequence. `dist/index.js` is unchanged (`extract` is not yet reachable from `main.ts`; ncc tree-shakes it).

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (no `dist/` diff, as expected)
- [ ] End-to-end extraction of a real GMAT tarball — deferred to the action's self-CI matrix once download → extract → api-startup → smoke is wired up.

Closes #6