### PR TITLE
Run BuildApiStartupFile.py against installed GMAT root

### DIFF
--- a/src/api_startup.ts
+++ b/src/api_startup.ts
@@ -1,0 +1,37 @@
+import * as path from 'node:path';
+import * as core from '@actions/core';
+import * as exec from '@actions/exec';
+import * as io from '@actions/io';
+
+export async function buildApiStartupFile(gmatRoot: string, pythonVersion?: string): Promise<void> {
+  const pythonPath = await resolvePython();
+  const script = path.join(gmatRoot, 'api', 'BuildApiStartupFile.py');
+  if (pythonVersion !== undefined) {
+    core.info(
+      `Running BuildApiStartupFile.py with ${pythonPath} (requested python-version=${pythonVersion})`,
+    );
+  } else {
+    core.info(`Running BuildApiStartupFile.py with ${pythonPath}`);
+  }
+  try {
+    await exec.exec(pythonPath, [script], { cwd: gmatRoot });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `BuildApiStartupFile.py failed in ${gmatRoot}: ${reason}. ` +
+        `Without api/api_startup_file.txt, gmatpy import will fail at runtime.`,
+    );
+  }
+}
+
+async function resolvePython(): Promise<string> {
+  try {
+    return await io.which('python', true);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `python is not on PATH (${reason}). ` +
+        `Add a 'uses: actions/setup-python@v5' step before setup-gmat.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- New `src/api_startup.ts` exporting `buildApiStartupFile(gmatRoot, pythonVersion?)`. Resolves `python` via `@actions/io`'s `which('python', true)` — a missing binary throws a typed error that points at `actions/setup-python@v5` as the fix.
- Invokes `python "${gmatRoot}/api/BuildApiStartupFile.py"` via `@actions/exec`'s `exec`, with `cwd` set to GMAT_ROOT. `exec` streams stdout/stderr live to the workflow log by default, so any Python/gmatpy output surfaces verbatim; non-zero exits are wrapped with context that names the runtime consequence (no `api_startup_file.txt` → cryptic `gmatpy` import failure).
- The optional `pythonVersion` parameter is accepted per the AC signature and logged for diagnostic clarity. It does not select a different binary at this layer — consumers pin the interpreter with `actions/setup-python` ahead of `setup-gmat`. Treating it as a binary selector would expand scope beyond the AC.
- Not yet wired into `install.ts`; `dist/index.js` is unchanged because the new module is unreachable from `main.ts`.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (no `dist/` diff, as expected)
- [ ] End-to-end run against a real GMAT install — deferred to the action's self-CI matrix once the install path is fully wired up.

Closes #7