### PR TITLE
Add gmatpy smoke check via stock GMAT sample

### DIFF
--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -1,0 +1,58 @@
+import * as path from 'node:path';
+import * as core from '@actions/core';
+import * as exec from '@actions/exec';
+import * as io from '@actions/io';
+
+const SMOKE_SAMPLE = path.posix.join('samples', 'Ex_HighFidelitySRP.script');
+
+const SMOKE_PYTHON_SRC = `
+import os, sys
+gmat_root = os.environ['GMAT_ROOT']
+sys.path.insert(0, os.path.join(gmat_root, 'bin'))
+import gmatpy as gmat
+gmat.Setup(os.path.join(gmat_root, 'bin', 'api_startup_file.txt'))
+script = os.path.join(gmat_root, ${JSON.stringify(SMOKE_SAMPLE)})
+if not gmat.LoadScript(script):
+    sys.exit(f'gmat.LoadScript failed for {script}')
+rc = gmat.RunScript()
+if rc != 1:
+    sys.exit(f'gmat.RunScript returned {rc} for {script} (expected 1)')
+print('setup-gmat smoke ok')
+`;
+
+export async function smoke(gmatRoot: string, pythonVersion?: string): Promise<void> {
+  const pythonPath = await resolvePython();
+  const sample = path.join(gmatRoot, SMOKE_SAMPLE);
+  if (pythonVersion !== undefined) {
+    core.info(
+      `Smoke-testing GMAT install at ${gmatRoot} with ${pythonPath} (requested python-version=${pythonVersion})`,
+    );
+  } else {
+    core.info(`Smoke-testing GMAT install at ${gmatRoot} with ${pythonPath}`);
+  }
+  try {
+    await exec.exec(pythonPath, ['-c', SMOKE_PYTHON_SRC], {
+      cwd: gmatRoot,
+      env: { ...process.env, GMAT_ROOT: gmatRoot } as { [key: string]: string },
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Smoke check failed: ${reason}. ` +
+        `Sample: ${sample}. GMAT_ROOT: ${gmatRoot}. ` +
+        `See the workflow log above for gmatpy's stderr.`,
+    );
+  }
+}
+
+async function resolvePython(): Promise<string> {
+  try {
+    return await io.which('python', true);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `python is not on PATH (${reason}). ` +
+        `Add a 'uses: actions/setup-python@v5' step before setup-gmat.`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- New `src/smoke.ts` exporting `smoke(gmatRoot, pythonVersion?)`. Resolves `python` via `@actions/io`'s `which('python', true)` (typed error if missing, surfacing `actions/setup-python@v5` as the fix).
- Runs `python -c "..."` that bootstraps `gmatpy` from `${gmatRoot}/bin`, calls `gmat.Setup` against `api_startup_file.txt` from the previous step, loads `samples/Ex_HighFidelitySRP.script`, and asserts `gmat.RunScript` returns `1` (GMAT's success code).
- `@actions/exec.exec` streams stdout/stderr live to the workflow log by default and throws on non-zero exit, so any gmatpy import / parse / propagate failure surfaces verbatim. Failures are wrapped with the sample path and GMAT_ROOT for the action's failure summary.
- Sample choice: `Ex_HighFidelitySRP.script` — smallest stock sample with `Propagate`, no Subscribers (no `ReportFile`/`OpenFramesInterface` deps). Header reports `Released: R2014a`, so it ships in every supported version.
- Not yet wired into `install.ts`; `dist/index.js` is unchanged because `smoke` is unreachable from `main.ts`.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (no `dist/` diff, as expected)
- [ ] End-to-end smoke against a real GMAT install — deferred to the action's self-CI matrix once the install path is wired up.

Closes #8