### PR TITLE
Cache GMAT install via @actions/cache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,38 @@
+import * as nodeOs from 'node:os';
+import * as path from 'node:path';
+import * as cache from '@actions/cache';
+import * as core from '@actions/core';
+
+const ACTION_MAJOR_VERSION = 'v0';
+
+export async function restoreCache(version: string): Promise<{ hit: boolean; path: string }> {
+  const installPath = canonicalInstallPath();
+  const key = composeKey(version);
+  core.info(`Restoring GMAT cache (key=${key}, path=${installPath})`);
+  const matched = await cache.restoreCache([installPath], key);
+  return { hit: matched !== undefined, path: installPath };
+}
+
+export async function saveCache(version: string, installPath: string): Promise<void> {
+  const key = composeKey(version);
+  core.info(`Saving GMAT cache (key=${key}, path=${installPath})`);
+  try {
+    await cache.saveCache([installPath], key);
+  } catch (err) {
+    if (err instanceof cache.ReserveCacheError) {
+      core.warning(`Cache already exists for key ${key}, skipping save: ${err.message}`);
+      return;
+    }
+    throw err;
+  }
+}
+
+function composeKey(version: string): string {
+  const runnerOs = process.env.RUNNER_OS ?? 'unknown-os';
+  const runnerArch = process.env.RUNNER_ARCH ?? 'unknown-arch';
+  return `setup-gmat-${ACTION_MAJOR_VERSION}-${version}-${runnerOs}-${runnerArch}`;
+}
+
+function canonicalInstallPath(): string {
+  return path.join(process.env.RUNNER_TEMP ?? nodeOs.tmpdir(), 'gmat');
+}


### PR DESCRIPTION
## Summary

- New `src/cache.ts` exporting `restoreCache(version)` and `saveCache(version, path)`. Both compose the cache key as `setup-gmat-${ACTION_MAJOR_VERSION}-${version}-${RUNNER_OS}-${RUNNER_ARCH}` and target the canonical install path (`${RUNNER_TEMP}/gmat`) — the same location `extract.ts` produces.
- `restoreCache` returns `{ hit, path }`. No `restoreKeys` fallback — a near-miss restore would put the wrong GMAT version under our canonical path.
- `saveCache` catches `ReserveCacheError` (raised when another concurrent job already saved this key) and warns rather than failing, matching `actions/cache`'s own behavior. Other errors bubble.
- The "post-extract / pre-`BuildApiStartupFile`" timing from the charter is the orchestrator's responsibility, not `cache.ts`'s. This module is timing-agnostic; the wire-up issue calls `saveCache` after `extract` returns and before `buildApiStartupFile` runs.
- `ACTION_MAJOR_VERSION` is hard-coded at `"v0"` for the pre-1.0 line. Bump to `"v1"` at the v1.0.0 release cut so v0 caches don't collide with v1 caches.
- Not yet wired into `install.ts`; `dist/index.js` is unchanged.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (no `dist/` diff, as expected)
- [ ] End-to-end restore/save against a real cache backend — requires runner-injected `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN`; deferred to the action's self-CI matrix once the install path is wired up.

Closes #9