### PR TITLE
Add self-test job: Ubuntu × R2026a + cache equivalence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,65 @@ jobs:
             git diff --stat dist
             exit 1
           fi
+
+  self-test:
+    name: self-test
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install GMAT (run 1)
+        id: install-1
+        uses: ./
+        with:
+          version: R2026a
+          cache: true
+
+      - name: Snapshot install after run 1
+        run: |
+          find "$GMAT_ROOT" -type f \
+            ! -name 'api_startup_file.txt' \
+            ! -path '*/__pycache__/*' \
+            ! -name '*.pyc' \
+            -print0 | sort -z | xargs -0 sha256sum > /tmp/manifest-1.txt
+          wc -l /tmp/manifest-1.txt
+
+      - name: Reset install path
+        run: rm -rf "$GMAT_ROOT"
+
+      - name: Install GMAT (run 2)
+        id: install-2
+        uses: ./
+        with:
+          version: R2026a
+          cache: true
+
+      - name: Assert cache-hit on run 2
+        run: |
+          if [ "${{ steps.install-2.outputs.cache-hit }}" != "true" ]; then
+            echo "::error::Expected cache-hit=true on run 2, got '${{ steps.install-2.outputs.cache-hit }}'"
+            exit 1
+          fi
+
+      - name: Snapshot install after run 2
+        run: |
+          find "$GMAT_ROOT" -type f \
+            ! -name 'api_startup_file.txt' \
+            ! -path '*/__pycache__/*' \
+            ! -name '*.pyc' \
+            -print0 | sort -z | xargs -0 sha256sum > /tmp/manifest-2.txt
+          wc -l /tmp/manifest-2.txt
+
+      - name: Cache equivalence
+        run: |
+          if ! diff -u /tmp/manifest-1.txt /tmp/manifest-2.txt; then
+            echo "::error::Cache restore differs from cache-saved state"
+            exit 1
+          fi
+          echo "Cache equivalence OK"


### PR DESCRIPTION
## Summary

- New `self-test` job in `.github/workflows/ci.yml` runs the action against itself on every PR — install once, install again from cache, assert `cache-hit=true` on the second run.
- Equivalence check: sha256-manifest of `$GMAT_ROOT` before and after the cache cycle must be identical. Excludes `api_startup_file.txt` (path-embedded by `BuildApiStartupFile.py`) and `__pycache__`/`.pyc` (Python bytecode produced by the smoke step's `gmatpy` import).
- `$GMAT_ROOT` is removed between runs, so install-2 can only succeed via a real cache restore.
- Sequenced after `build` (`needs: build`) so we don't burn ~10 minutes self-testing a bundle that's about to be flagged as out-of-sync.

## Status

**Blocked on #27** — the first run surfaced a pre-existing bug in `extract.ts:locateGmatRoot`: it only looks at depth 0 and 1, but the R2026a Linux tarball wraps GMAT in two levels (`GMAT/R2026a/...`). Self-test cannot pass until #27 is fixed and this PR is rebased on `main`.

## Test plan

- [ ] Once #27 lands, rebase this PR — install-1 cache-miss (~5 min), install-2 reports `cache-hit=true`, equivalence diff empty.
- [ ] On a re-push to this branch: install-1 may itself be a hit (branch-scoped cache from prior push); install-2 still asserts hit and equivalence still passes.
- [ ] Total job runtime stays under the 25-minute timeout.

## Out of scope

- macOS / Windows runners (v0.2).
- Multi-version matrix (v0.2).
- Adding `self-test` to `main`'s required status checks — separate decision.

Closes #11