### PR TITLE
docs: rewrite README around real v0.1 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # setup-gmat
 
-GitHub Action and canonical Docker image for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General Mission Analysis Tool) and bootstrapping `gmatpy` in CI.
+GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General Mission Analysis Tool) and bootstrapping `gmatpy` in CI.
 
 ```yaml
-- uses: astro-tools/setup-gmat@v1
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.12'
+- uses: astro-tools/setup-gmat@v0
   with:
     version: R2026a
     cache: true
 - run: python -c "import gmatpy"
 ```
 
-```bash
-docker run --rm -it ghcr.io/astro-tools/gmat:R2026a python -c "import gmatpy"
-```
-
 ## Status
 
-Under active development. The v0.1 install path is not implemented yet — invoking the action today fails with an explicit "not implemented" message.
+v0.1 is the first usable release. It installs GMAT R2026a on Linux runners, caches the install across runs, and exports `GMAT_ROOT` to the workflow environment. Additional runners (Windows, macOS) and the R2022a–R2025a version matrix are tracked under v0.2; see the [Roadmap](#roadmap) below.
 
-## What it does (planned)
+## What it does
 
 - Resolves the GMAT installer URL for the requested version and runner OS.
 - Restores the install from cache, or downloads and extracts a fresh copy.
@@ -28,14 +27,65 @@ Under active development. The v0.1 install path is not implemented yet — invok
 
 `actions/setup-python` (or any equivalent that puts `python` on PATH) is a prerequisite — setup-gmat does not bundle its own Python interpreter.
 
+## Supported versions (v0.1)
+
+| Runner          | GMAT version |
+| --------------- | ------------ |
+| `ubuntu-latest` | R2026a       |
+
+The action pulls GMAT's generic Linux x86_64 build, so other Linux runners with a recent glibc should work — but `ubuntu-latest` is the only configuration exercised in CI for v0.1. Windows and macOS runners, and the R2022a / R2025a versions, are scoped for v0.2.
+
+## Quick start
+
+A complete workflow that installs GMAT, runs `gmatpy`, and is shaped as a matrix so it expands cleanly when v0.2 adds more versions:
+
+```yaml
+name: gmat-ci
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gmat-version: [R2026a]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - id: gmat
+        uses: astro-tools/setup-gmat@v0
+        with:
+          version: ${{ matrix.gmat-version }}
+          cache: true
+
+      - name: Smoke check gmatpy
+        run: python -c "import gmatpy; print(gmatpy.__file__)"
+
+      - name: Show install metadata
+        run: |
+          echo "GMAT_ROOT=${{ steps.gmat.outputs.gmat-root }}"
+          echo "version=${{ steps.gmat.outputs.gmat-version }}"
+          echo "cache-hit=${{ steps.gmat.outputs.cache-hit }}"
+```
+
+## Documentation
+
+Full documentation lives at **<https://astro-tools.github.io/setup-gmat/>** — getting started, inputs and outputs, recipes, FAQ, and troubleshooting.
+
 ## Roadmap
 
-| Release    | Scope                                                                        |
-| ---------- | ---------------------------------------------------------------------------- |
-| v0.1 (MVP) | Linux + R2026a, basic caching, smoke check, gmat-run CI consumes the action. |
-| v0.2       | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
-| v0.3       | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
-| v1.0       | Public API stability; at least two external consumers shipped on the action. |
+| Release      | Scope                                                                        |
+| ------------ | ---------------------------------------------------------------------------- |
+| v0.1 *(current)* | Linux + R2026a, basic caching, smoke check, gmat-run CI consumes the action. |
+| v0.2         | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
+| v0.3         | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
+| v1.0         | Public API stability; at least two external consumers shipped on the action. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Full documentation lives at **<https://astro-tools.github.io/setup-gmat/>** — 
 
 ## Roadmap
 
-| Release      | Scope                                                                        |
-| ------------ | ---------------------------------------------------------------------------- |
-| v0.1 *(current)* | Linux + R2026a, basic caching, smoke check, gmat-run CI consumes the action. |
-| v0.2         | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
-| v0.3         | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
-| v1.0         | Public API stability; at least two external consumers shipped on the action. |
+| Release          | Scope                                                                        |
+| ---------------- | ---------------------------------------------------------------------------- |
+| v0.1 _(current)_ | Linux + R2026a, basic caching, smoke check, gmat-run CI consumes the action. |
+| v0.2             | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
+| v0.3             | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
+| v1.0             | Public API stability; at least two external consumers shipped on the action. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General M
 - uses: actions/setup-python@v5
   with:
     python-version: '3.12'
-- uses: astro-tools/setup-gmat@v0
+- uses: astro-tools/setup-gmat@v0.1
   with:
     version: R2026a
     cache: true
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.12'
 
       - id: gmat
-        uses: astro-tools/setup-gmat@v0
+        uses: astro-tools/setup-gmat@v0.1
         with:
           version: ${{ matrix.gmat-version }}
           cache: true


### PR DESCRIPTION
## Summary

- Replaces the "not implemented" Status block with what v0.1 actually ships (Linux `ubuntu-latest` × R2026a, caching, smoke check).
- Adds a Supported-versions table, a worked matrix-shaped Quick start, and a link to the published docs site at https://astro-tools.github.io/setup-gmat/.
- Top example switches to `astro-tools/setup-gmat@v0` with `actions/setup-python` as the documented prerequisite. Lead `docker run` line is dropped — the GHCR image is v0.3 scope.

## Test plan

- [x] CI green (build / lint / typecheck / dist-check still pass; README isn't covered by any of them, so this is just a sanity check that no other state was disturbed).
- [x] Visual proofread of the rendered README on the PR page — table formatting, code-block fences, anchor link to `#roadmap`.
- [ ] Confirm the Quick-start snippet's input / output names match `action.yml` (`version`, `cache`; `gmat-root`, `gmat-version`, `cache-hit`).

## Notes

- Out of scope: `docs/index.md` and `docs/getting-started.md` carry the same outdated "not yet usable" / "once v0.1 ships" framing — they need a parallel pass but that's a docs-site PR, not a README PR.
- `CHANGELOG.md` deliberately untouched; per workspace convention, CHANGELOG entries land at release-cut, not per PR.

Closes #12.