### PR TITLE
docs: real v0.1 content (getting started, inputs/outputs, FAQ, troubleshooting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General M
   with:
     version: R2026a
     cache: true
-- run: python -c "import gmatpy"
 ```
 
 ## Status
@@ -63,9 +62,6 @@ jobs:
         with:
           version: ${{ matrix.gmat-version }}
           cache: true
-
-      - name: Smoke check gmatpy
-        run: python -c "import gmatpy; print(gmatpy.__file__)"
 
       - name: Show install metadata
         run: |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,51 @@
 # FAQ
 
-Will be populated as v0.1 features ship.
+## Why do I need `actions/setup-python` before `setup-gmat`?
+
+`setup-gmat` shells out to Python twice: once to run `BuildApiStartupFile.py`, once for an internal smoke check that imports `gmatpy` and runs a stock sample. Both calls resolve `python` from `PATH` via [`@actions/io`'s `which`](https://github.com/actions/toolkit/tree/main/packages/io). The action does not bundle its own interpreter; it deliberately defers the Python version choice to the workflow.
+
+If `python` isn't on `PATH`, the action fails with:
+
+```
+python is not on PATH (...). Add a 'uses: actions/setup-python@v5' step before setup-gmat.
+```
+
+Any mechanism that puts a `python` binary on `PATH` works — `actions/setup-python` is the standard one. GMAT R2026a's pre-built `gmatpy` modules support Python 3.9 through 3.14.
+
+## When does the GMAT cache get invalidated?
+
+The cache key is `setup-gmat-v0-${version}-${RUNNER_OS}-${RUNNER_ARCH}` — see [Inputs and outputs → Cache key](inputs-outputs.md#cache-key). The cache misses (and a fresh download runs) when:
+
+- You change the `version` input.
+- GitHub upgrades the runner image to a different `RUNNER_OS` or `RUNNER_ARCH` label.
+- A breaking change to setup-gmat's cache layout bumps the `v0` prefix in a future major release.
+
+The key is **not** sensitive to the action's minor or patch version, the upstream installer's checksum, or the `api_startup_file.txt` written per Python ABI. To force a fresh install in a single run without changing inputs, pass `cache: false`.
+
+## Which GMAT versions are supported?
+
+v0.1 supports **R2026a only**, on Linux runners. Any other value for `version` raises a validation error at parse time, before any download.
+
+The v0.2 milestone expands support to **R2022a, R2025a, and R2026a** across Linux, Windows, and macOS. NASA never released R2023a or R2024a — there are no SourceForge tarballs for those versions, and they will not appear in any version matrix this action ships.
+
+## Why does `python -c "import gmatpy"` fail in a step after `setup-gmat`?
+
+`gmatpy` lives at `$GMAT_ROOT/bin/gmatpy/`, which is not on Python's import path by default — `setup-gmat` does not modify `PYTHONPATH`. Set it on the step that needs it:
+
+```yaml
+- run: python -c "import gmatpy"
+  env:
+    PYTHONPATH: ${{ env.GMAT_ROOT }}/bin
+```
+
+See [Getting started → Calling gmatpy from your own steps](getting-started.md#calling-gmatpy-from-your-own-steps) for the recommended patterns. The action's own smoke check works because it uses `sys.path.insert` from inside an inlined Python script, not `PYTHONPATH`.
+
+## Can I use setup-gmat outside CI, on my laptop?
+
+The action is built around the `@actions/*` toolkit and assumes a runner-like environment (`RUNNER_TEMP`, `GITHUB_ENV`, `actions/cache`). It is not designed for direct local invocation.
+
+For local use, install GMAT directly from [SourceForge](https://sourceforge.net/projects/gmat/) and run `BuildApiStartupFile.py` against it manually. A canonical Docker image on GHCR is planned for **v0.3** but is not yet published.
+
+## Does setup-gmat verify the download?
+
+It checks the archive size against a hardcoded minimum (≈380 MiB for R2026a) before extraction, which catches truncated downloads and SourceForge HTML-mirror responses. It does **not** verify a checksum or signature in v0.1 — supply-chain hardening (cosign-signed Docker image, attested provenance) is on the v0.3 roadmap.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ This page walks through the minimum CI workflow that installs GMAT R2026a and ru
 ## Prerequisites
 
 - A Linux runner. v0.1 is exercised on `ubuntu-latest`; other Linux runners with a recent glibc should work but are not covered by setup-gmat's CI.
-- `python` on `PATH` *before* `setup-gmat` runs. The action shells out to `BuildApiStartupFile.py` and runs an internal smoke check; both invoke whatever Python `which python` resolves. The action does **not** bundle its own interpreter. Use [`actions/setup-python`](https://github.com/actions/setup-python) (or any equivalent) to put one on PATH.
+- `python` on `PATH` _before_ `setup-gmat` runs. The action shells out to `BuildApiStartupFile.py` and runs an internal smoke check; both invoke whatever Python `which python` resolves. The action does **not** bundle its own interpreter. Use [`actions/setup-python`](https://github.com/actions/setup-python) (or any equivalent) to put one on PATH.
 
 ## Minimum workflow
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,20 +1,84 @@
 # Getting started
 
-This page will walk through the minimum workflow to install GMAT in CI once v0.1 ships.
+This page walks through the minimum CI workflow that installs GMAT R2026a and runs your own `gmatpy` code on top of it.
+
+## Prerequisites
+
+- A Linux runner. v0.1 is exercised on `ubuntu-latest`; other Linux runners with a recent glibc should work but are not covered by setup-gmat's CI.
+- `python` on `PATH` *before* `setup-gmat` runs. The action shells out to `BuildApiStartupFile.py` and runs an internal smoke check; both invoke whatever Python `which python` resolves. The action does **not** bundle its own interpreter. Use [`actions/setup-python`](https://github.com/actions/setup-python) (or any equivalent) to put one on PATH.
+
+## Minimum workflow
 
 ```yaml
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: astro-tools/setup-gmat@v1
+
+      - uses: astro-tools/setup-gmat@v0.1
         with:
           version: R2026a
-      - run: python -c "import gmatpy"
 ```
 
-Python on PATH is a prerequisite — setup-gmat invokes `BuildApiStartupFile.py` and does not bundle its own interpreter. Run `actions/setup-python` (or any other mechanism that puts a `python` binary on PATH) before `setup-gmat`.
+When this step finishes, the job has:
+
+- GMAT installed under `$GMAT_ROOT` (`$RUNNER_TEMP/gmat`), exported into the workflow environment.
+- `gmatpy` available at `$GMAT_ROOT/bin/gmatpy/` and registered against the active Python ABI by `BuildApiStartupFile.py`.
+- An action-internal smoke check that has already loaded and run a stock GMAT sample (`samples/Ex_HighFidelitySRP.script`), so a successful step is positive proof the install is callable.
+
+## Calling gmatpy from your own steps
+
+`gmatpy` lives at `$GMAT_ROOT/bin/gmatpy/`, which is **not** on Python's import path by default — `setup-gmat` does not modify `PYTHONPATH`. Two patterns work; pick whichever fits how your code is invoked.
+
+### Pattern 1 — set `PYTHONPATH` on the step
+
+```yaml
+- name: Run mission script
+  run: python my_mission.py
+  env:
+    PYTHONPATH: ${{ env.GMAT_ROOT }}/bin
+```
+
+`${{ env.GMAT_ROOT }}` resolves at step prep time, by which point `setup-gmat` has already exported the variable. This is the simplest form for one-off scripts and `pytest` invocations.
+
+### Pattern 2 — `sys.path.insert` from inside Python
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.environ['GMAT_ROOT'], 'bin'))
+import gmatpy as gmat
+
+gmat.Setup(os.path.join(os.environ['GMAT_ROOT'], 'bin', 'api_startup_file.txt'))
+# ... use gmat.LoadScript, gmat.RunScript, etc.
+```
+
+Note the `gmat.Setup(...)` call — GMAT requires the API startup file to be loaded once before the rest of the API is usable. `BuildApiStartupFile.py` writes that file during `setup-gmat`; your code points GMAT at it.
+
+This pattern is more portable than `PYTHONPATH` because it travels with the script, regardless of how Python is invoked.
+
+## Reading outputs
+
+`setup-gmat` exposes three outputs and one environment variable. See [Inputs and outputs](inputs-outputs.md) for the full reference. A typical use:
+
+```yaml
+- id: gmat
+  uses: astro-tools/setup-gmat@v0.1
+  with:
+    version: R2026a
+
+- name: Show install metadata
+  run: |
+    echo "version=${{ steps.gmat.outputs.gmat-version }}"
+    echo "root=${{ steps.gmat.outputs.gmat-root }}"
+    echo "cache-hit=${{ steps.gmat.outputs.cache-hit }}"
+```
+
+## Next steps
+
+- Caching, the install layout, and the cache key's exact shape are documented in [Inputs and outputs](inputs-outputs.md#cache-key).
+- Common failures and their precise error strings are in [Troubleshooting](troubleshooting.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,18 +3,21 @@
 A GitHub Action that installs [NASA GMAT](https://gmat.gsfc.nasa.gov/) and bootstraps `gmatpy` for use in CI workflows.
 
 ```yaml
-- uses: astro-tools/setup-gmat@v1
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.12'
+- uses: astro-tools/setup-gmat@v0.1
   with:
     version: R2026a
-- run: python -c "import gmatpy"
-```
-
-A canonical Docker image on GitHub Container Registry is published alongside the action for ad-hoc local use and for downstream container layering.
-
-```bash
-docker run --rm -it ghcr.io/astro-tools/gmat:R2026a python -c "import gmatpy"
 ```
 
 ## Status
 
-setup-gmat is under active development. The action is not yet usable.
+v0.1 is the first usable release: GMAT R2026a on Linux runners (`ubuntu-latest`), caching across runs, and a built-in smoke check that loads and runs a stock GMAT sample. Windows and macOS support and the R2022a–R2026a version matrix are scoped for v0.2; see the [README roadmap](https://github.com/astro-tools/setup-gmat#roadmap) for the full plan.
+
+## Where to next
+
+- [Getting started](getting-started.md) — minimum workflow, prerequisites, and how to call `gmatpy` from your own steps.
+- [Inputs and outputs](inputs-outputs.md) — full reference for `action.yml`, including cache key shape and install layout.
+- [FAQ](faq.md) — Python prerequisite, cache invalidation, supported versions.
+- [Troubleshooting](troubleshooting.md) — known failure modes mapped to the action's error messages.

--- a/docs/inputs-outputs.md
+++ b/docs/inputs-outputs.md
@@ -2,18 +2,18 @@
 
 ## Inputs
 
-| Name             | Required | Default  | Description                                                                                                                                                                                  |
-| ---------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`        | no       | `R2026a` | GMAT release to install. v0.1 supports `R2026a` only. Any other value raises a validation error before the download starts.                                                                  |
-| `cache`          | no       | `true`   | Cache the resolved install across runs via `actions/cache`. Pass `'false'` to force a fresh download every run.                                                                              |
+| Name             | Required | Default  | Description                                                                                                                                                                                       |
+| ---------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`        | no       | `R2026a` | GMAT release to install. v0.1 supports `R2026a` only. Any other value raises a validation error before the download starts.                                                                       |
+| `cache`          | no       | `true`   | Cache the resolved install across runs via `actions/cache`. Pass `'false'` to force a fresh download every run.                                                                                   |
 | `python-version` | no       | `''`     | Informational only — the value is logged but does **not** select the interpreter. To pin Python, configure [`actions/setup-python`](https://github.com/actions/setup-python) before `setup-gmat`. |
 
 ## Outputs
 
-| Name           | Description                                                                                  |
-| -------------- | -------------------------------------------------------------------------------------------- |
-| `gmat-root`    | Absolute path to the resolved GMAT install root. Equal to `$RUNNER_TEMP/gmat` in v0.1.       |
-| `gmat-version` | GMAT release that was installed. Echoes the validated `version` input.                       |
+| Name           | Description                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| `gmat-root`    | Absolute path to the resolved GMAT install root. Equal to `$RUNNER_TEMP/gmat` in v0.1.        |
+| `gmat-version` | GMAT release that was installed. Echoes the validated `version` input.                        |
 | `cache-hit`    | `'true'` if the install was restored from cache, `'false'` if downloaded and extracted fresh. |
 
 ## Environment variables
@@ -28,13 +28,13 @@ GMAT is extracted to `$RUNNER_TEMP/gmat` (the same path is reported as `gmat-roo
 
 Notable paths under `$GMAT_ROOT`:
 
-| Path                              | What's there                                                                              |
-| --------------------------------- | ----------------------------------------------------------------------------------------- |
-| `bin/`                            | GMAT shared libraries, `GmatConsole`, and the `gmatpy` package.                            |
-| `bin/gmatpy/`                     | The Python package. Add `bin/` to `PYTHONPATH` or `sys.path` to import it.                |
-| `bin/api_startup_file.txt`        | Written by `BuildApiStartupFile.py`; passed to `gmat.Setup(...)` before the API is usable. |
-| `api/BuildApiStartupFile.py`      | The bootstrap script `setup-gmat` runs after extraction.                                   |
-| `samples/`                        | Stock GMAT mission scripts. The action's smoke check uses `Ex_HighFidelitySRP.script`.     |
+| Path                         | What's there                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------ |
+| `bin/`                       | GMAT shared libraries, `GmatConsole`, and the `gmatpy` package.                            |
+| `bin/gmatpy/`                | The Python package. Add `bin/` to `PYTHONPATH` or `sys.path` to import it.                 |
+| `bin/api_startup_file.txt`   | Written by `BuildApiStartupFile.py`; passed to `gmat.Setup(...)` before the API is usable. |
+| `api/BuildApiStartupFile.py` | The bootstrap script `setup-gmat` runs after extraction.                                   |
+| `samples/`                   | Stock GMAT mission scripts. The action's smoke check uses `Ex_HighFidelitySRP.script`.     |
 
 ## Cache key
 

--- a/docs/inputs-outputs.md
+++ b/docs/inputs-outputs.md
@@ -2,20 +2,58 @@
 
 ## Inputs
 
-| Name             | Required | Default  | Description                                                                              |
-| ---------------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
-| `version`        | no       | `R2026a` | GMAT release to install. v0.1 supports `R2026a` only on Linux.                           |
-| `cache`          | no       | `true`   | Cache the resolved install across runs via `actions/cache`.                              |
-| `python-version` | no       | `""`     | Python interpreter for `BuildApiStartupFile.py`. If empty, the `python` on PATH is used. |
+| Name             | Required | Default  | Description                                                                                                                                                                                  |
+| ---------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`        | no       | `R2026a` | GMAT release to install. v0.1 supports `R2026a` only. Any other value raises a validation error before the download starts.                                                                  |
+| `cache`          | no       | `true`   | Cache the resolved install across runs via `actions/cache`. Pass `'false'` to force a fresh download every run.                                                                              |
+| `python-version` | no       | `''`     | Informational only — the value is logged but does **not** select the interpreter. To pin Python, configure [`actions/setup-python`](https://github.com/actions/setup-python) before `setup-gmat`. |
 
 ## Outputs
 
-| Name           | Description                                                           |
-| -------------- | --------------------------------------------------------------------- |
-| `gmat-root`    | Absolute path to the resolved GMAT install root.                      |
-| `gmat-version` | GMAT release that was installed.                                      |
-| `cache-hit`    | `"true"` if the install was restored from cache, `"false"` otherwise. |
+| Name           | Description                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| `gmat-root`    | Absolute path to the resolved GMAT install root. Equal to `$RUNNER_TEMP/gmat` in v0.1.       |
+| `gmat-version` | GMAT release that was installed. Echoes the validated `version` input.                       |
+| `cache-hit`    | `'true'` if the install was restored from cache, `'false'` if downloaded and extracted fresh. |
 
 ## Environment variables
 
-The action exports `GMAT_ROOT` into the workflow environment so subsequent steps see the install root without having to read the action output.
+`setup-gmat` exports `GMAT_ROOT` into the workflow environment, so subsequent steps can reference `$GMAT_ROOT` (or `${{ env.GMAT_ROOT }}` in expressions) without reading the action output.
+
+`PYTHONPATH` is **not** modified. To `import gmatpy` from your own steps, set `PYTHONPATH=${{ env.GMAT_ROOT }}/bin` per-step or `sys.path.insert` from inside Python — see [Getting started → Calling gmatpy from your own steps](getting-started.md#calling-gmatpy-from-your-own-steps).
+
+## Install path and layout
+
+GMAT is extracted to `$RUNNER_TEMP/gmat` (the same path is reported as `gmat-root`). The action overwrites this directory if it already exists.
+
+Notable paths under `$GMAT_ROOT`:
+
+| Path                              | What's there                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `bin/`                            | GMAT shared libraries, `GmatConsole`, and the `gmatpy` package.                            |
+| `bin/gmatpy/`                     | The Python package. Add `bin/` to `PYTHONPATH` or `sys.path` to import it.                |
+| `bin/api_startup_file.txt`        | Written by `BuildApiStartupFile.py`; passed to `gmat.Setup(...)` before the API is usable. |
+| `api/BuildApiStartupFile.py`      | The bootstrap script `setup-gmat` runs after extraction.                                   |
+| `samples/`                        | Stock GMAT mission scripts. The action's smoke check uses `Ex_HighFidelitySRP.script`.     |
+
+## Cache key
+
+When `cache: true`, the install is keyed as:
+
+```
+setup-gmat-v0-${version}-${RUNNER_OS}-${RUNNER_ARCH}
+```
+
+For example: `setup-gmat-v0-R2026a-Linux-X64`. The key changes when:
+
+- The `version` input changes.
+- GitHub upgrades the runner image to a different `RUNNER_OS` / `RUNNER_ARCH` label.
+- A breaking change to the action's cache layout bumps the `v0` prefix in a future major release of setup-gmat.
+
+The key is **not** sensitive to the action's minor or patch version, the upstream installer's checksum, or the contents of `BuildApiStartupFile.py`. To force a fresh install in a single run without changing inputs, pass `cache: false`.
+
+See [GitHub's cache scope rules](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) for cross-branch and cross-PR behavior.
+
+## Download integrity
+
+Before extraction, the action verifies the downloaded archive against a hardcoded minimum size (≈380 MiB for R2026a). A truncated, redirected, or HTML-mirror response fails fast with an explicit error rather than producing a confusing extraction failure later. See [Troubleshooting → Installer download appears truncated](troubleshooting.md#installer-download-appears-truncated).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,80 @@
 # Troubleshooting
 
-Will be populated as v0.1 features ship.
+When a `setup-gmat` step fails, the action emits a precise error pointing at one of the failure modes below. Match the error string in the workflow log to a section here.
+
+## Installer download appears truncated
+
+```
+GMAT R2026a installer download appears truncated.
+Observed 12.4 MiB (13002432 bytes), expected at least 380.0 MiB.
+URL: https://sourceforge.net/projects/gmat/files/GMAT/GMAT-R2026a/gmat-ubuntu-x64-R2026a.tar.gz/download
+```
+
+Before extraction, the action sanity-checks the downloaded archive against a hardcoded minimum size. The most common causes:
+
+- **SourceForge served an HTML mirror page instead of the archive.** Re-running the workflow usually clears it; the SourceForge mirror network occasionally hands back a redirect/landing page sized in kilobytes.
+- **Network interruption mid-download.** The error fires fast, before extraction; safe to re-run.
+- **Upstream pulled the release.** If retries don't help, the SourceForge URL may have changed or the tarball may have been replaced. Open an issue.
+
+The threshold (≈380 MiB for R2026a) is hardcoded; a download below it is treated as failure regardless of whether extraction would have succeeded.
+
+## `python` is not on `PATH`
+
+```
+python is not on PATH (...).
+Add a 'uses: actions/setup-python@v5' step before setup-gmat.
+```
+
+`setup-gmat` shells out to Python twice — once for `BuildApiStartupFile.py`, once for the internal smoke check. Both call `which python` and fail loudly if no `python` binary is resolvable. Fix by ordering `actions/setup-python` (or any equivalent) before `setup-gmat`:
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: '3.12'
+
+- uses: astro-tools/setup-gmat@v0.1
+```
+
+The `python-version` input on `setup-gmat` itself is informational and does **not** select the interpreter — see [Inputs and outputs](inputs-outputs.md#inputs).
+
+## `BuildApiStartupFile.py` failed
+
+```
+BuildApiStartupFile.py failed in /home/runner/work/_temp/gmat: <subprocess exit message>.
+Without api/api_startup_file.txt, gmatpy import will fail at runtime.
+```
+
+`BuildApiStartupFile.py` writes `bin/api_startup_file.txt`, which `gmat.Setup()` reads on import. If it fails, the install is unusable even though the tarball extracted cleanly. Common causes:
+
+- **Mismatched Python ABI.** GMAT R2026a ships pre-built `gmatpy` modules for Python 3.9 through 3.14. Running `BuildApiStartupFile.py` under a Python outside that range will fail. Pin a supported version via `actions/setup-python`.
+- **Permissions on `$GMAT_ROOT/api/`.** The script writes inside the install tree; if the runner has restrictive umask or the path was made read-only by a previous step, the write fails. Default GitHub-hosted runners do not have this issue.
+- **Corrupted cache.** A previous run may have saved a partial install. Pass `cache: false` once to force a fresh download.
+
+The full subprocess output appears in the workflow log immediately above this error — read it for the underlying Python traceback.
+
+## Smoke check failed
+
+```
+Smoke check failed: <subprocess exit message>.
+Sample: /home/runner/work/_temp/gmat/samples/Ex_HighFidelitySRP.script.
+GMAT_ROOT: /home/runner/work/_temp/gmat.
+See the workflow log above for gmatpy's stderr.
+```
+
+After installing, the action loads and runs a stock sample (`Ex_HighFidelitySRP.script`) end-to-end as proof that `gmatpy` is callable. A failure here means the install is broken in a way `BuildApiStartupFile.py` did not catch — typically a missing shared library or an ABI/Python mismatch that only surfaces at first `gmat.Setup()`.
+
+Read the stderr above the error for the underlying gmatpy / GMAT message. If you see a missing-shared-library error (e.g. `libGmatBase.so` failing to load), check whether a custom runner image is interfering with the cached install — passing `cache: false` and re-running is the fastest diagnostic.
+
+## Archive layout drift
+
+```
+Expected GMAT/R2026a/api/BuildApiStartupFile.py inside the installer,
+but /tmp/.../GMAT/R2026a/api/BuildApiStartupFile.py is missing.
+Did the upstream archive layout change?
+```
+
+`setup-gmat` resolves `GMAT_ROOT` by an exact path inside the tarball (`GMAT/<version>/`). If NASA changes the layout in a future release, this error fires immediately rather than producing a half-installed tree. v0.1 is pinned to R2026a, whose layout is stable. If you see this error against R2026a, the tarball is either corrupt locally or has been replaced upstream — open an issue.
+
+## Cache restore differs from a fresh install
+
+This is not an error setup-gmat raises, but it can show up in workflows that snapshot `$GMAT_ROOT` and assert on its contents. The action's own self-test (`.github/workflows/ci.yml`, the `self-test` job) verifies bit-for-bit equivalence between a fresh download and a cache restore for everything *except* `bin/api_startup_file.txt` and `__pycache__/` directories. Drift in those two paths is expected — they're regenerated per Python ABI when `BuildApiStartupFile.py` runs against the restored install.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,4 +77,4 @@ Did the upstream archive layout change?
 
 ## Cache restore differs from a fresh install
 
-This is not an error setup-gmat raises, but it can show up in workflows that snapshot `$GMAT_ROOT` and assert on its contents. The action's own self-test (`.github/workflows/ci.yml`, the `self-test` job) verifies bit-for-bit equivalence between a fresh download and a cache restore for everything *except* `bin/api_startup_file.txt` and `__pycache__/` directories. Drift in those two paths is expected — they're regenerated per Python ABI when `BuildApiStartupFile.py` runs against the restored install.
+This is not an error setup-gmat raises, but it can show up in workflows that snapshot `$GMAT_ROOT` and assert on its contents. The action's own self-test (`.github/workflows/ci.yml`, the `self-test` job) verifies bit-for-bit equivalence between a fresh download and a cache restore for everything _except_ `bin/api_startup_file.txt` and `__pycache__/` directories. Drift in those two paths is expected — they're regenerated per Python ABI when `BuildApiStartupFile.py` runs against the restored install.


### PR DESCRIPTION
## Summary

- Rewrites `docs/getting-started.md`, `docs/inputs-outputs.md`, `docs/faq.md`, and `docs/troubleshooting.md` against the actual v0.1 surface (action.yml + src/install.ts), replacing the placeholder copy.
- Refreshes `docs/index.md`: drops the "not yet usable" status, drops the unreleased Docker/GHCR reference (planned for v0.3), aligns the example with `@v0.1`.
- Drops the two `python -c "import gmatpy"` snippets from `README.md`. They're redundant with the action's internal smoke check, and they were misleading because `gmatpy` is not on `sys.path`/`PYTHONPATH` in downstream steps — `setup-gmat` only exports `GMAT_ROOT`. The docs cover the correct `PYTHONPATH=$GMAT_ROOT/bin` pattern in getting-started + FAQ + inputs-outputs.

Acceptance criteria from #13:

- [x] `docs/getting-started.md` walks through the minimum workflow with a runnable example.
- [x] `docs/inputs-outputs.md` is accurate to the shipped `action.yml` (notes that `python-version` is informational, documents the install layout and cache key shape).
- [x] `docs/faq.md` covers ≥3 expected questions (Python prereq, cache invalidation, supported versions — plus 3 more: PYTHONPATH gotcha, local-use scope, integrity verification scope).
- [x] `docs/troubleshooting.md` covers common failure modes (mid-download abort, missing python, BuildApiStartupFile failure — plus smoke-check failure, archive layout drift, cache-vs-fresh equivalence).
- [x] `mkdocs build --strict` passes.

## Test plan

- [x] `mkdocs build --strict` locally — clean exit, no warnings.
- [x] CI's `Docs / build` job passes (it runs the same `mkdocs build --strict`).
- [ ] Reviewer reads through each page for tone/accuracy and verifies the cross-page anchors render in the deployed preview if one is built.

Closes #13