### PR TITLE
docs: v0.1 recipes pages (pytest, mission script, skip-on-docs)

### DIFF
--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,3 +1,9 @@
 # Recipes
 
-Worked examples of common workflow shapes will land here as v0.1 features ship.
+Worked-example workflows for common shapes. Each recipe runs as-is on `ubuntu-latest` against `astro-tools/setup-gmat@v0.1` — no external dependencies, no secret-gated steps. Copy, adapt, ship.
+
+- [Run pytest against gmatpy](pytest.md) — install GMAT and run a `pytest` suite whose tests `import gmatpy`. Sets `PYTHONPATH` on the test step.
+- [Run a mission script and upload its report](run-mission-script.md) — drive a `.script` file via `gmatpy.LoadScript` / `RunScript` from Python, write a report, and upload it as a build artifact.
+- [Skip the GMAT install on docs-only changes](skip-on-docs.md) — use `paths-ignore` to keep the heavy install off PRs that only touch READMEs or `docs/`. Includes the inverse `paths` filter for docs-only jobs.
+
+For the underlying mechanics each recipe builds on, see [Getting started](../getting-started.md), [Inputs and outputs](../inputs-outputs.md), and [Troubleshooting](../troubleshooting.md).

--- a/docs/recipes/pytest.md
+++ b/docs/recipes/pytest.md
@@ -1,0 +1,60 @@
+# Run pytest against gmatpy
+
+A workflow that installs GMAT, then runs a `pytest` suite whose tests `import gmatpy`. The test step sets `PYTHONPATH=$GMAT_ROOT/bin` so `gmatpy` resolves on import — see [Getting started → Calling gmatpy from your own steps](../getting-started.md#calling-gmatpy-from-your-own-steps) for why this is necessary.
+
+## Workflow
+
+```yaml
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0.1
+        with:
+          version: R2026a
+
+      - name: Install test dependencies
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/ -v
+        env:
+          PYTHONPATH: ${{ env.GMAT_ROOT }}/bin
+```
+
+`${{ env.GMAT_ROOT }}` resolves at step prep time, by which point `setup-gmat` has already exported the variable. Setting `PYTHONPATH` on a single step is the lightest-touch form — it doesn't leak into other steps, doesn't require touching `sys.path` in the test code, and works with both `pytest` and plain `python -m`.
+
+## Example test
+
+```python
+# tests/test_propagation.py
+import os
+
+import gmatpy as gmat
+
+
+def test_smoke():
+    gmat.Setup(os.path.join(os.environ['GMAT_ROOT'], 'bin', 'api_startup_file.txt'))
+    sample = os.path.join(os.environ['GMAT_ROOT'], 'samples', 'Ex_HighFidelitySRP.script')
+    assert gmat.LoadScript(sample)
+    assert gmat.RunScript() == 1  # GMAT returns 1 on success
+```
+
+Note the `gmat.Setup(...)` call — GMAT requires the API startup file to be loaded once before the rest of the API is usable. `setup-gmat` writes that file during install; tests point GMAT at it via `$GMAT_ROOT`.
+
+For larger suites, lift `gmat.Setup(...)` into a session-scoped `pytest` fixture so it runs once per test process.
+
+## Common failures
+
+- `ModuleNotFoundError: No module named 'gmatpy'` — the test step is missing `PYTHONPATH=${{ env.GMAT_ROOT }}/bin`. The action does **not** modify `PYTHONPATH` by design; see [Inputs and outputs → Environment variables](../inputs-outputs.md#environment-variables).
+- `python is not on PATH` raised by `setup-gmat` itself — `actions/setup-python` is missing or sequenced after `setup-gmat`. See [Troubleshooting → `python` is not on `PATH`](../troubleshooting.md#python-is-not-on-path).

--- a/docs/recipes/run-mission-script.md
+++ b/docs/recipes/run-mission-script.md
@@ -1,0 +1,90 @@
+# Run a mission script and upload its report
+
+A workflow that installs GMAT, runs a `.script` mission file via `gmatpy.LoadScript` / `RunScript` from a small Python driver, then uploads the resulting report directory as a build artifact.
+
+The example uses the stock `samples/Ex_HighFidelitySRP.script` shipped inside the GMAT install, so the recipe runs as-is without any user-supplied script. Substitute your own `.script` path for real mission analysis.
+
+## Workflow
+
+```yaml
+name: run-mission
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0.1
+        with:
+          version: R2026a
+
+      - name: Run mission script
+        run: python run_mission.py
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mission-reports
+          path: reports/
+          if-no-files-found: error
+```
+
+`if: always()` on the upload step keeps the report artifact available even when the mission run fails — the partial output is usually what you want to inspect. `if-no-files-found: error` turns a silently-empty `reports/` into a hard failure, which catches cases where the driver wrote to the wrong directory.
+
+## Driver script
+
+```python
+# run_mission.py
+import os
+import sys
+from pathlib import Path
+
+GMAT_ROOT = Path(os.environ['GMAT_ROOT'])
+sys.path.insert(0, str(GMAT_ROOT / 'bin'))
+
+import gmatpy as gmat
+
+REPORTS = Path('reports')
+REPORTS.mkdir(exist_ok=True)
+
+gmat.Setup(str(GMAT_ROOT / 'bin' / 'api_startup_file.txt'))
+
+script = GMAT_ROOT / 'samples' / 'Ex_HighFidelitySRP.script'
+if not gmat.LoadScript(str(script)):
+    sys.exit(f'gmat.LoadScript failed for {script}')
+if gmat.RunScript() != 1:
+    sys.exit(f'gmat.RunScript did not return 1 for {script}')
+
+# After RunScript, the propagated spacecraft holds its final state.
+sc = gmat.GetObject('aSpacecraft')
+fields = ['Epoch', 'X', 'Y', 'Z', 'VX', 'VY', 'VZ']
+with (REPORTS / 'final_state.csv').open('w') as out:
+    out.write(','.join(fields) + '\n')
+    out.write(','.join(str(sc.GetField(name)) for name in fields) + '\n')
+
+print(f'wrote {REPORTS / "final_state.csv"}')
+```
+
+The `sys.path.insert` pattern (Pattern 2 in [Getting started](../getting-started.md#calling-gmatpy-from-your-own-steps)) is the right choice for a self-contained driver — the import path travels with the script, so it works the same whether invoked by CI, by `python run_mission.py` locally, or by an IDE.
+
+If your `.script` file uses `Create ReportFile` resources to write its own outputs, change directory to `reports/` before `LoadScript` so GMAT's relative report paths land alongside the Python-written files:
+
+```python
+os.chdir(REPORTS)
+```
+
+The samples shipped in `$GMAT_ROOT/samples/` are documented in the GMAT user guide; their paths and resource names are stable across R2026a. See [Inputs and outputs → Install path and layout](../inputs-outputs.md#install-path-and-layout) for the full directory map.
+
+## Common failures
+
+- `gmat.LoadScript failed for <path>` — the script path is wrong, or the script references files (e.g. `SPADSRPFile`) that resolve to paths outside the install. Verify the path; for stock samples, use `$GMAT_ROOT/samples/<name>.script`.
+- `gmat.RunScript did not return 1` — GMAT returns `1` on success and other values on failure (a confusing convention inherited from the engine). The full GMAT engine log appears above this line in the workflow output; read it for the underlying cause.
+- Empty `reports/` artifact — the driver ran but did not write anything under `reports/`. Check that `REPORTS.mkdir(exist_ok=True)` ran before any output and that the driver's working directory is what you expect.

--- a/docs/recipes/skip-on-docs.md
+++ b/docs/recipes/skip-on-docs.md
@@ -38,7 +38,7 @@ A PR that only touches `**.md` or anything under `docs/**` is now skipped entire
 
 ## The inverse — docs-only jobs
 
-For a separate workflow that builds docs and should *only* run on docs changes, use `paths` (the inverse of `paths-ignore`):
+For a separate workflow that builds docs and should _only_ run on docs changes, use `paths` (the inverse of `paths-ignore`):
 
 ```yaml
 name: docs
@@ -69,7 +69,7 @@ This pattern keeps the docs build off the critical path of every code PR while s
 
 ## Required-status-check gotcha
 
-If branch protection requires the GMAT-install workflow as a status check, a `paths-ignore`-skipped run produces *no* status — not a passing one — which can block PRs from merging. Two common fixes:
+If branch protection requires the GMAT-install workflow as a status check, a `paths-ignore`-skipped run produces _no_ status — not a passing one — which can block PRs from merging. Two common fixes:
 
 - **Drop the requirement** for that workflow if the docs paths are genuinely safe to merge without it.
 - **Add a thin always-runs job** in the same workflow file that produces the required status. The skip filter applies per-workflow, not per-job, but you can split the heavy work into a separate workflow that's `paths-ignore`-filtered while a lightweight workflow with the same required status name runs unconditionally.

--- a/docs/recipes/skip-on-docs.md
+++ b/docs/recipes/skip-on-docs.md
@@ -1,0 +1,77 @@
+# Skip the GMAT install on docs-only changes
+
+Installing GMAT R2026a is a multi-hundred-megabyte download and a few minutes of CI time. Skipping the install on docs-only changes (READMEs, MkDocs pages, design notes) keeps PRs cheap when no code is touched.
+
+The fix is GitHub's built-in `paths-ignore` filter on the workflow trigger.
+
+## Skip the heavy install on docs-only changes
+
+```yaml
+name: gmat-ci
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astro-tools/setup-gmat@v0.1
+        with:
+          version: R2026a
+      # ... your test / propagation steps
+```
+
+A PR that only touches `**.md` or anything under `docs/**` is now skipped entirely — no install, no cache restore, no smoke check.
+
+## The inverse — docs-only jobs
+
+For a separate workflow that builds docs and should *only* run on docs changes, use `paths` (the inverse of `paths-ignore`):
+
+```yaml
+name: docs
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict
+```
+
+This pattern keeps the docs build off the critical path of every code PR while still gating docs changes on a successful build.
+
+## Required-status-check gotcha
+
+If branch protection requires the GMAT-install workflow as a status check, a `paths-ignore`-skipped run produces *no* status — not a passing one — which can block PRs from merging. Two common fixes:
+
+- **Drop the requirement** for that workflow if the docs paths are genuinely safe to merge without it.
+- **Add a thin always-runs job** in the same workflow file that produces the required status. The skip filter applies per-workflow, not per-job, but you can split the heavy work into a separate workflow that's `paths-ignore`-filtered while a lightweight workflow with the same required status name runs unconditionally.
+
+GitHub's documentation calls this the "required check that never runs" problem; the workaround you choose depends on how strict your branch protection needs to be.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,9 @@ nav:
   - Inputs and outputs: inputs-outputs.md
   - Recipes:
       - recipes/index.md
+      - Run pytest against gmatpy: recipes/pytest.md
+      - Run a mission script and upload its report: recipes/run-mission-script.md
+      - Skip the GMAT install on docs-only changes: recipes/skip-on-docs.md
   - FAQ: faq.md
   - Troubleshooting: troubleshooting.md
 


### PR DESCRIPTION
## Summary

- Replaces the placeholder \`docs/recipes/index.md\` with three worked-example recipes plus a real landing page.
- \`recipes/pytest.md\` — workflow runs \`pytest\` against a \`tests/\` dir importing \`gmatpy\`, sets \`PYTHONPATH=$GMAT_ROOT/bin\` on the test step (Pattern 1 from getting-started).
- \`recipes/run-mission-script.md\` — drives \`samples/Ex_HighFidelitySRP.script\` via \`gmatpy.LoadScript\` / \`RunScript\` from a Python driver (Pattern 2), writes a CSV report from the propagated spacecraft state, uploads via \`actions/upload-artifact@v4\` with \`if: always()\` and \`if-no-files-found: error\`.
- \`recipes/skip-on-docs.md\` — \`paths-ignore\` on the heavy install workflow, the inverse \`paths\` filter for docs-only jobs, and the required-status-check gotcha called out.
- Wires the three recipes into the \`Recipes:\` section of \`mkdocs.yml\`.

Each recipe runs as-is on \`ubuntu-latest\` with no external dependencies. Cross-links to \`getting-started.md\`, \`inputs-outputs.md\`, and \`troubleshooting.md\` carry the underlying mechanics rather than re-explaining them — matches the v0.1 doc tone established in #30.

Acceptance criteria from #31:

- [x] \`docs/recipes/pytest.md\` — full pytest + \`gmatpy\` workflow, cross-linked to Getting started.
- [x] \`docs/recipes/run-mission-script.md\` — \`.script\` runner with report upload, uses \`Ex_HighFidelitySRP.script\`.
- [x] \`docs/recipes/skip-on-docs.md\` — \`paths-ignore\` plus inverse \`paths\` filter.
- [x] \`docs/recipes/index.md\` — landing page replacing the placeholder.
- [x] \`mkdocs build --strict\` passes (verified locally; CI's \`Docs / build\` runs the same command).

## Test plan

- [x] \`mkdocs build --strict\` locally — clean exit, no warnings.
- [x] CI's \`Docs / build\` job passes.
- [ ] Reviewer reads through each page for tone/accuracy and verifies the cross-page anchors render in the deployed preview if one is built.

Closes #31