### PR TITLE
docs: pin examples to @v0 instead of @v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General M
 - uses: actions/setup-python@v5
   with:
     python-version: '3.12'
-- uses: astro-tools/setup-gmat@v0.1
+- uses: astro-tools/setup-gmat@v0
   with:
     version: R2026a
     cache: true
@@ -58,7 +58,7 @@ jobs:
           python-version: '3.12'
 
       - id: gmat
-        uses: astro-tools/setup-gmat@v0.1
+        uses: astro-tools/setup-gmat@v0
         with:
           version: ${{ matrix.gmat-version }}
           cache: true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: astro-tools/setup-gmat@v0.1
+      - uses: astro-tools/setup-gmat@v0
         with:
           version: R2026a
 ```
@@ -67,7 +67,7 @@ This pattern is more portable than `PYTHONPATH` because it travels with the scri
 
 ```yaml
 - id: gmat
-  uses: astro-tools/setup-gmat@v0.1
+  uses: astro-tools/setup-gmat@v0
   with:
     version: R2026a
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ A GitHub Action that installs [NASA GMAT](https://gmat.gsfc.nasa.gov/) and boots
 - uses: actions/setup-python@v5
   with:
     python-version: '3.12'
-- uses: astro-tools/setup-gmat@v0.1
+- uses: astro-tools/setup-gmat@v0
   with:
     version: R2026a
 ```

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,6 +1,6 @@
 # Recipes
 
-Worked-example workflows for common shapes. Each recipe runs as-is on `ubuntu-latest` against `astro-tools/setup-gmat@v0.1` — no external dependencies, no secret-gated steps. Copy, adapt, ship.
+Worked-example workflows for common shapes. Each recipe runs as-is on `ubuntu-latest` against `astro-tools/setup-gmat@v0` — no external dependencies, no secret-gated steps. Copy, adapt, ship.
 
 - [Run pytest against gmatpy](pytest.md) — install GMAT and run a `pytest` suite whose tests `import gmatpy`. Sets `PYTHONPATH` on the test step.
 - [Run a mission script and upload its report](run-mission-script.md) — drive a `.script` file via `gmatpy.LoadScript` / `RunScript` from Python, write a report, and upload it as a build artifact.

--- a/docs/recipes/pytest.md
+++ b/docs/recipes/pytest.md
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: astro-tools/setup-gmat@v0.1
+      - uses: astro-tools/setup-gmat@v0
         with:
           version: R2026a
 

--- a/docs/recipes/run-mission-script.md
+++ b/docs/recipes/run-mission-script.md
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: astro-tools/setup-gmat@v0.1
+      - uses: astro-tools/setup-gmat@v0
         with:
           version: R2026a
 

--- a/docs/recipes/skip-on-docs.md
+++ b/docs/recipes/skip-on-docs.md
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: astro-tools/setup-gmat@v0.1
+      - uses: astro-tools/setup-gmat@v0
         with:
           version: R2026a
       # ... your test / propagation steps

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ Add a 'uses: actions/setup-python@v5' step before setup-gmat.
   with:
     python-version: '3.12'
 
-- uses: astro-tools/setup-gmat@v0.1
+- uses: astro-tools/setup-gmat@v0
 ```
 
 The `python-version` input on `setup-gmat` itself is informational and does **not** select the interpreter — see [Inputs and outputs](inputs-outputs.md#inputs).


### PR DESCRIPTION
## Summary

- Replaces all 10 \`astro-tools/setup-gmat@v0.1\` references in user-facing docs with \`astro-tools/setup-gmat@v0\` so consumers pin to a floating major-version tag, matching the GitHub Actions Marketplace convention (\`actions/checkout@v5\`, \`actions/setup-python@v6\`).
- Touches \`README.md\` (2), \`docs/index.md\`, \`docs/getting-started.md\` (2), \`docs/troubleshooting.md\`, \`docs/recipes/index.md\`, \`docs/recipes/pytest.md\`, \`docs/recipes/run-mission-script.md\`, \`docs/recipes/skip-on-docs.md\`.
- Pure find-and-replace; no other content changes.

## Test plan

- [x] \`grep -rn 'setup-gmat@v0\.1' README.md docs/\` returns nothing.
- [x] \`mkdocs build --strict\` passes locally.
- [x] \`npm run format:check\` passes locally.
- [x] CI's \`Docs / build\` and \`CI / build\` jobs pass.

Closes #33