### PR TITLE
chore: cut v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,22 @@
 All notable changes to setup-gmat are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-04-30
+
+First usable release. Installs GMAT R2026a on Ubuntu runners and bootstraps gmatpy for use in CI.
+
+### Added
+
+- GitHub Action that installs GMAT for the requested version on the requested runner OS, runs `BuildApiStartupFile.py`, and smoke-checks the install with a one-line gmatpy propagation against a stock sample (#19, #20, #21, #22, #23, #25).
+- Inputs: `version` (default `R2026a`), `cache` (default `true`), `python-version` (optional override) (#19).
+- Outputs: `gmat-root`, `gmat-version`, `cache-hit`. `GMAT_ROOT` is also exported to the workflow environment so subsequent steps see it without reading outputs (#25).
+- Install caching via `@actions/cache`, keyed on action major version, GMAT version, runner OS, and runner architecture (#24).
+- Self-CI on `ubuntu-latest` × `R2026a` running two consecutive jobs (cache miss, then cache hit) and asserting the resolved root is byte-identical between runs (#26).
+- Node 24 runtime, single-file `dist/index.js` bundle via `@vercel/ncc`, and a CI gate that fails the build if `dist/` drifts from `src/` (#1, #18).
+- MkDocs Material documentation site at <https://astro-tools.github.io/setup-gmat/>: getting started, inputs/outputs reference, FAQ, troubleshooting, and recipes (pytest, mission script, skip-on-docs) (#13, #14, #30, #31, #32).
+- README rewritten around real v0.1 usage with a supported-versions table, Python prerequisite, and a matrix-CI quick-start (#12, #29, #34).
+
+### Fixed
+
+- Resolve `GMAT_ROOT` by walking installer wrapper directories instead of guessing a fixed depth, so installs whose archive layout adds an extra wrapper level still resolve correctly (#28).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Full documentation lives at **<https://astro-tools.github.io/setup-gmat/>** — 
 
 | Release          | Scope                                                                        |
 | ---------------- | ---------------------------------------------------------------------------- |
-| v0.1 _(current)_ | Linux + R2026a, basic caching, smoke check, gmat-run CI consumes the action. |
+| v0.1 _(current)_ | Linux + R2026a, basic caching, smoke check.                                  |
 | v0.2             | Windows + macOS, R2022a–R2026a matrix, weekly self-CI cron.                  |
 | v0.3             | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
 | v1.0             | Public API stability; at least two external consumers shipped on the action. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-gmat",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "GitHub Action to install NASA GMAT (General Mission Analysis Tool) and bootstrap gmatpy in CI.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Populate `CHANGELOG.md` with the `[0.1.0] - 2026-04-30` section, aggregated from the 14 merged PRs (1 Fixed, the rest Added).
- Bump `package.json` version from `0.0.0` to `0.1.0`.
- Trim the v0.1 row in the README roadmap so it no longer claims "gmat-run CI consumes the action" — that work was deferred to post-v0.3 in #16.

## Test plan

- [ ] `npm run all` green locally (format:check, lint, typecheck, build) — no `dist/` change.
- [ ] CI green on the PR (build + dist-check + self-test on Ubuntu × R2026a).
- [ ] CHANGELOG renders correctly on the GitHub PR view.

## Follow-ups (post-merge, tracked alongside #15)

- Cut `v0.1.0` annotated tag on the merge commit; create floating `v0` major tag at the same SHA.
- Create the GitHub Release from `v0.1.0` with the CHANGELOG section as the body, and submit the action to GitHub Marketplace under "Continuous integration".
- Post the release announcement in `astro-tools/.github` Discussions → Announcements.

Closes #15.