### PR TITLE
Add weekly self-CI cron on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Weekly re-run of the self-test matrix to catch SourceForge URL drift,
+  # mirror retirements, and installer-archive layout changes before
+  # downstream consumers do. Mondays 06:00 UTC (low-traffic window).
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds a `schedule: '0 6 * * 1'` trigger (Mondays 06:00 UTC) to `.github/workflows/ci.yml` so the existing self-test matrix re-runs weekly on `main` and surfaces SourceForge URL drift / installer-layout changes before downstream consumers hit them.
- Adds `workflow_dispatch` alongside, so the matrix can be triggered manually from the Actions UI without waiting for the cron window — useful for verifying the path post-merge and for running the matrix on demand after upstream changes.
- No matrix or job-graph changes; `build` → `self-test` runs unchanged on the new triggers.

## Test plan
- [x] CI is green on this PR (regular `pull_request` triggers).
- [ ] After merge, confirm the workflow's Schedule trigger appears in `gh workflow view CI` / the Actions UI.
- [ ] Trigger via `workflow_dispatch` once on `main` post-merge to prove the cron path runs the full matrix end-to-end (cron itself can only be observed on the next Monday).

Closes #41