### PR TITLE
Use uv for R2022a Python install in self-test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,22 @@ jobs:
       # Python 3.9 reached EOL 2025-10 and is no longer in the windows-latest
       # tool cache, so actions/setup-python's manifest install adds ~55s per
       # R2022a run. uv pulls 3.9 from python-build-standalone in seconds.
+      # setup-uv only sets UV_PYTHON; the install + PATH step below makes
+      # `python` resolve to it for the action's BuildApiStartupFile call.
       - if: matrix.version == 'R2022a'
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
+
+      - if: matrix.version == 'R2022a'
+        name: Put uv-installed Python on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv python install
+          python_bin="$(uv python find)"
+          echo "Resolved Python: ${python_bin}"
+          dirname "${python_bin}" >> "$GITHUB_PATH"
 
       - if: matrix.version != 'R2022a'
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      # Python 3.9 reached EOL 2025-10 and is no longer in the windows-latest
+      # tool cache, so actions/setup-python's manifest install adds ~55s per
+      # R2022a run. uv pulls 3.9 from python-build-standalone in seconds.
+      - if: matrix.version == 'R2022a'
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - if: matrix.version != 'R2022a'
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Splits the single `actions/setup-python@v5` step in `ci.yml`'s self-test matrix into two conditional steps: `astral-sh/setup-uv@v6` for R2022a cells, `actions/setup-python@v5` for R2025a/R2026a.
- R2022a needs Python 3.9 (R2022a's Windows/macOS `gmatpy` ships `_py36..._py39` only), and 3.9 reached EOL 2025-10 → no longer in the `windows-latest` tool cache → cold manifest install ~55s per run. uv pulls 3.9 from `python-build-standalone` in seconds.
- No change to action surface (`action.yml` / `dist/`), no change to README / docs — this is purely the action's own self-test wiring.

## Test plan
- [x] All 8 self-test cells pass (smoke + cache equivalence).
- [x] `windows-latest × R2022a` job time drops by ≥30s vs the baseline run on `main` (~95s on run 25224730765).
- [x] `Install GMAT (run 1)` step on Win R2022a succeeds — proves the uv-installed Python is on PATH for `BuildApiStartupFile.py`.

Closes #54