### PR TITLE
docs: troubleshooting + FAQ for Windows/macOS and version gap

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,14 @@ python is not on PATH (...). Add a 'uses: actions/setup-python@v5' step before s
 
 Any mechanism that puts a `python` binary on `PATH` works — `actions/setup-python` is the standard one. The Python version you pin must match a `gmatpy` binding shipped by the GMAT release you're installing — R2022a covers 3.6–3.9 (Linux extends to 3.10), R2025a covers 3.9–3.12, R2026a covers 3.9–3.14. See the [Python ABI table](https://github.com/astro-tools/setup-gmat#python-abi-per-gmat-release) in the README for the cross-OS view.
 
+## Are there OS-specific Python gotchas?
+
+Mostly not — the action shells out to whatever `python` is on `PATH` on every OS. The differences worth knowing:
+
+- **Linux**: standard. Pin a `python-version` inside the GMAT release's ABI window and you're done. No platform-specific quirks.
+- **Windows**: pin a `python-version` that `actions/setup-python` actually publishes a Windows build for; an unpublished version installs nothing and the next step that needs `python` fails with the usual "not on PATH" error. On self-hosted Windows runners, the Windows Store launcher stub at `%LocalAppData%\Microsoft\WindowsApps\python.exe` can intercept `which python` even after `setup-python` runs successfully — see [Troubleshooting → `python` is not on `PATH`](troubleshooting.md#python-is-not-on-path) for the fix.
+- **macOS**: `macos-latest` is Apple Silicon (arm64) since 2024. `actions/setup-python` installs an arm64 Python, which is the right choice for R2025a and R2026a (their DMGs ship arm64-compatible `gmatpy` bindings) but **not** for R2022a — its DMG is x86_64-only. Either pick a different GMAT version on `macos-latest` or move R2022a coverage to a non-macOS runner. See [Troubleshooting → macOS architecture mismatch](troubleshooting.md#macos-architecture-mismatch-r2022a-only).
+
 ## When does the GMAT cache get invalidated?
 
 The cache key is `setup-gmat-v0-${version}-${RUNNER_OS}-${RUNNER_ARCH}` — see [Inputs and outputs → Cache key](inputs-outputs.md#cache-key). The cache misses (and a fresh download runs) when:
@@ -26,7 +34,19 @@ The key is **not** sensitive to the action's minor or patch version, the upstrea
 
 The action installs **R2022a, R2025a, or R2026a** on Linux, Windows, and macOS runners — with one exception: R2022a is not supported on `macos-latest`. R2022a's macOS DMG ships x86_64-only `gmatpy` `.so` files (predates Apple Silicon entirely) and Apple Silicon Python cannot dlopen them. R2025a and R2026a ship arm64-compatible bindings and run natively on Apple Silicon. See the [supported-versions matrix](https://github.com/astro-tools/setup-gmat#supported-versions) in the README for the full table.
 
-Any other value for `version` raises a validation error at parse time, before any download. NASA never released R2023a or R2024a — there are no SourceForge artifacts for those versions, and they will not appear in any version matrix this action ships.
+Any other value for `version` raises a validation error at parse time, before any download. NASA never released R2023a or R2024a — see [What about R2023a and R2024a?](#what-about-r2023a-and-r2024a) below.
+
+## What about R2023a and R2024a?
+
+NASA never released them. The gap between R2022a and R2025a is real, not a packaging oversight on this action's part — there are no SourceForge artifacts for `R2023a` or `R2024a`, and `setup-gmat` will not add them.
+
+The version input is validated at parse time, so a workflow that asks for one of the missing releases fails fast before any download:
+
+```
+Unsupported GMAT version "R2023a". Supported versions: R2022a, R2025a, R2026a.
+```
+
+Don't add `R2023a` or `R2024a` to a matrix expecting them to be skipped — they're not on the to-do list and the validation error is intentional.
 
 ## Why does `python -c "import gmatpy"` fail in a step after `setup-gmat`?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,8 @@ Add a 'uses: actions/setup-python@v5' step before setup-gmat.
 
 The `python-version` input on `setup-gmat` itself is informational and does **not** select the interpreter — see [Inputs and outputs](inputs-outputs.md#inputs).
 
+On **Windows self-hosted runners**, `which python` can resolve to the Windows Store launcher stub at `%LocalAppData%\Microsoft\WindowsApps\python.exe` even after `actions/setup-python` runs successfully — the stub is a launcher that opens the Microsoft Store rather than executing Python, so `BuildApiStartupFile.py` either fails to start or falls through to the same "not on PATH" error from a downstream step. GitHub-hosted Windows runners do not hit this. On self-hosted runners, disable the App Execution Aliases for `python.exe` and `python3.exe` (Settings → Apps → Advanced app settings → App execution aliases), or move `setup-python`'s install directory ahead of `%LocalAppData%\Microsoft\WindowsApps` in the runner's system PATH. The other Windows-specific way to hit this error despite a green `setup-python` step is asking for a `python-version` that doesn't publish a Windows build — `setup-python` installs nothing and reports success, and the action then fails at the first `python` lookup.
+
 ## `BuildApiStartupFile.py` failed
 
 ```
@@ -83,6 +85,54 @@ Did the upstream archive layout change?
 ```
 
 If you hit either error against a supported `version`, the archive is either corrupt locally or has been replaced upstream — open an issue.
+
+## `hdiutil attach` failed (macOS)
+
+```
+hdiutil: attach failed - <reason>
+```
+
+The action mounts the GMAT DMG via `hdiutil attach -nobrowse -readonly -noautoopen` with empty stdin (to defend against an interactive license prompt blocking the runner). When `hdiutil` itself exits non-zero, its stderr bubbles up unwrapped — there is no `setup-gmat`-formatted error around it. Common causes:
+
+- **Truncated DMG** — `hdiutil: attach failed - no mountable file systems`. The download size check usually catches truncation earlier; if you reach `attach` with this error, the archive is corrupt past the prefix the size check inspects. Re-run the workflow; if it persists, open an issue.
+- **Mountpoint busy** — `hdiutil: attach failed - Resource busy`. A prior run on the same self-hosted runner left a mount under `$RUNNER_TEMP/gmat-dmg-mount-<uuid>`. The mountpoint is per-run UUID, so collisions only happen if a runner was killed mid-mount and reused the same `RUNNER_TEMP`. Manually `hdiutil detach -force <mountpoint>` and remove the directory.
+- **Permission denied** — the runner user can't access disk-arbitration or the temp directory. GitHub-hosted runners do not hit this; self-hosted macOS runners may need to relax sandboxing or run under an account that can mount disk images.
+
+## Stale DMG mountpoint after a killed runner (macOS)
+
+```
+hdiutil detach failed for /var/folders/.../gmat-dmg-mount-<uuid>: <reason>.
+Self-hosted runners may need manual cleanup.
+```
+
+This is a `warning`, not a hard failure — the install completed and the action proceeds. The detach in the action's `finally` block did not succeed, usually because the OS held a lock on the mount immediately after the copy (Spotlight indexing the freshly-visible files; antivirus scanning; an open Finder window despite `-nobrowse`). On GitHub-hosted runners the session ends and the mount is reclaimed automatically; on long-lived self-hosted runners the mountpoints can accumulate.
+
+To clean up manually:
+
+```bash
+hdiutil detach -force /var/folders/.../gmat-dmg-mount-<uuid>
+rm -rf /var/folders/.../gmat-dmg-mount-<uuid>
+```
+
+If this warning appears regularly on a self-hosted macOS runner, exclude `$RUNNER_TEMP` from Spotlight (`sudo mdutil -i off "$RUNNER_TEMP"`) — the indexer is the most common holder of mount locks immediately after the copy completes.
+
+## ZIP extraction fails on Windows
+
+The Windows install path uses `tc.extractZip` from `@actions/tool-cache`, which delegates to 7-Zip / `Expand-Archive` under the hood. Failures bubble up unwrapped — you see the underlying extractor's stderr in the workflow log, not a `setup-gmat`-formatted error. By far the most common cause on **self-hosted** Windows runners is path-length: the staged install path
+
+```
+%RUNNER_TEMP%\<random>\GMAT\R2025a\bin\gmatpy\_py312\<long file>
+```
+
+can exceed Windows' default `MAX_PATH` of 260 characters. GitHub-hosted Windows runners ship with long-path support enabled (`LongPathsEnabled=1` in the registry), so this primarily affects custom or self-hosted Windows runners.
+
+Fixes, in order of preference:
+
+- Enable long paths on the runner: set `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled = 1` in the registry, restart the runner service. If your workflow uses `git` on the same paths, also `git config --system core.longpaths true`.
+- Move `RUNNER_TEMP` to a shorter root (e.g. `C:\R\T`) to leave more headroom under the limit.
+- Switch the affected matrix cells to `windows-latest` (GitHub-hosted) where long paths are already enabled.
+
+If the error is something other than a path-length failure (corrupt zip, unexpected layout), see [Archive layout drift](#archive-layout-drift) — the Windows-side `findRootByApiStartup` probe surfaces layout problems with a `setup-gmat`-formatted error string.
 
 ## macOS architecture mismatch (R2022a only)
 


### PR DESCRIPTION
## Summary

- `docs/troubleshooting.md`: three new sections for platform-specific failure modes from the Windows (#48) and macOS (#49) installer paths — `hdiutil attach` failures (busy mountpoint, truncated DMG, permission), the `hdiutil detach` warning that leaves a stale mountpoint on killed self-hosted runners, and Windows ZIP extraction failures (path-length under `MAX_PATH=260` on self-hosted runners). Existing `python is not on PATH` section gets a Windows-specific note covering the WindowsApps store-stub interception and the unpublished-python-version case.
- `docs/faq.md`: new "Are there OS-specific Python gotchas?" entry summarising per-OS quirks (Linux: none; Windows: store-stub + unpublished `python-version`; macOS: arm64 vs R2022a x86_64 DMG), and a dedicated "What about R2023a and R2024a?" entry. The existing supported-versions entry links to the new entry instead of repeating the explanation.

## Test plan

- [x] `mkdocs build --strict` clean
- [x] `npx prettier --check docs/troubleshooting.md docs/faq.md` clean
- [x] Docs workflow green on CI

Closes #45