### PR TITLE
chore: cut v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,28 @@ All notable changes to setup-gmat are documented here. The format follows [Keep 
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-04-30
+## [0.2.0] - 2026-05-01
+
+Cross-platform coverage and full version matrix. setup-gmat now installs GMAT on Linux, Windows, and macOS runners against R2022a, R2025a, or R2026a — every cell of that matrix exercised in self-CI on every PR and on a weekly cron.
+
+### Added
+
+- Windows installer support and an OS-dispatch refactor that lifts the v0.1 Linux-hardcoded install path into per-OS `download` / `extract` modules (#48).
+- macOS DMG installer support: `hdiutil attach` (read-only, `-nobrowse`, mountpoint under `RUNNER_TEMP`), `cp -R` of the resolved root off the mount, `hdiutil detach` (#49).
+- Supported `version` input expanded from R2026a-only to R2022a, R2025a, and R2026a. R2023a and R2024a were never released by NASA and are explicitly rejected with a pointer to the FAQ (#47).
+- Installer SHA-256 (first 12 chars) folded into the cache key, so a re-uploaded installer at the same SourceForge URL invalidates cleanly without a version bump (#50).
+- Cross-platform self-CI matrix exercising every supported `(runner, version)` pair on every PR — `{ubuntu-latest, windows-latest, macos-latest}` × `{R2022a, R2025a, R2026a}`, with `macos-latest × R2022a` excluded (R2022a's macOS DMG ships x86_64-only `gmatpy` bindings and Apple Silicon runners cannot dlopen it) (#51).
+- Weekly self-CI cron on `main` (Mondays 06:00 UTC) — early-warning channel for SourceForge URL drift, mirror retirements, and installer-archive layout changes (#52).
+- Mirror-drift `drift.yml` workflow: a daily HEAD-only liveness check across every supported `(version, OS)` triple that fails before a download attempt would (#53).
+- `uv`-based Python 3.9 install for R2022a in the self-test matrix, since `actions/setup-python@v5` no longer ships 3.9 binaries on every runner (#55).
+- Multi-version compatibility recipe documenting the full `{ubuntu, windows, macos} × {R2022a, R2025a, R2026a}` matrix with the `macos × R2022a` exclude and per-version Python pin (#56).
+- Troubleshooting and FAQ updates covering Windows-specific failure modes, macOS DMG mount/architecture failures, and the R2023a / R2024a version gap (#57).
+- README and docs landing surface refreshed for the v0.2 surface: 3-OS quick-start matrix, supported-versions table, Python ABI per GMAT release table, and `_(current)_` roadmap row updated (#58).
+
+### Changed
+
+- v0.1's R2026a-hardcoded assumptions removed: cache key, smoke check, and version-resolution logic are now driven by the validated `version` input rather than embedded R2026a constants (audit folded into #47).
+- v0.1's Linux-hardcoded assumptions removed: `download` / `extract` / `GMAT_ROOT` resolution moved behind a per-OS dispatch instead of a single Linux tarball path (audit folded into #48).
 
 First usable release. Installs GMAT R2026a on Ubuntu runners and bootstraps gmatpy for use in CI.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-gmat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "GitHub Action to install NASA GMAT (General Mission Analysis Tool) and bootstrap gmatpy in CI.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Populate `CHANGELOG.md` with the `[0.2.0] - 2026-05-01` section, aggregated from the 11 merged v0.2 PRs (#47, #48, #49, #50, #51, #52, #53, #55, #56, #57, #58).
- Bump `package.json` `version` from `0.1.0` to `0.2.0`.

The v0.2 row in the README roadmap was already trimmed-and-relabelled (`v0.2 _(current)_`) by #58 ahead of the cut, mirroring the v0.1 cut precedent (#35), so no README change is needed here.

## Test plan

- [x] `npm run all` is green locally (format:check, lint, typecheck, build) — no `dist/` drift from the version bump.
- [x] Self-CI matrix passes on the PR (3 OS × 3 versions, with `macos-latest × R2022a` excluded).

## Post-merge checklist

- [ ] Cut `v0.2.0` annotated tag on the merge commit.
- [ ] Retag `v0` floating major tag at the same SHA.
- [ ] Create GitHub Release from `v0.2.0` with the CHANGELOG section as body.
- [ ] Post release announcement in `astro-tools/.github` Discussions → Announcements.

Closes #46.