### PR TITLE
Fix Dockerfile: bump pyenv pin and correct PYTHONPATH for gmatpy import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,10 +94,10 @@ RUN apt-get update \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-# pyenv pinned to v2.5.7. Tags on GitHub are mutable; pinning to the SHA
+# pyenv pinned to v2.6.28. Tags on GitHub are mutable; pinning to the SHA
 # prevents silent retargeting if the tag is ever moved.
 RUN git clone --no-checkout https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" \
-    && git -C "${PYENV_ROOT}" checkout f216b4bfb1598347137ecb3c4a8f893baf9ea37f
+    && git -C "${PYENV_ROOT}" checkout 485090e7131630b191305316571c06e4ecac3a35
 
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,11 +119,13 @@ COPY --from=gmat-installer /staging/GMAT/${GMAT_VERSION} /opt/gmat
 # bakes in the staging path and gmatpy import fails cryptically at runtime.
 RUN cd /opt/gmat && python api/BuildApiStartupFile.py
 
-# A fresh image has no PYTHONPATH; the issue spec's `$GMAT_ROOT/api:$PYTHONPATH`
-# would expand to a trailing colon, which Python interprets as CWD on sys.path.
-# Set the path absolutely.
+# gmatpy ships at `<gmat_root>/bin/gmatpy/`, not under `api/` — `api/` carries
+# the load_gmat.py / BuildApiStartupFile.py entry scripts but the package
+# itself (and api_startup_file.txt) lives in bin/. PYTHONPATH set absolutely;
+# `$GMAT_ROOT/bin:$PYTHONPATH` would expand to a trailing colon on a fresh
+# image and put CWD on sys.path.
 ENV GMAT_ROOT=/opt/gmat \
-    PYTHONPATH=/opt/gmat/api
+    PYTHONPATH=/opt/gmat/bin
 
 # INSTALLER_SHA256 and ACTION_VERSION default to empty for local builds; the
 # publish workflow (#61) computes/passes them at build time.


### PR DESCRIPTION
## Summary

Two fixes to the Dockerfile so the canonical GMAT base image actually builds and `import gmatpy` works.

### 1. Bump pyenv pin to v2.6.28

- Pin moves from v2.5.7 (`f216b4bf…`) to v2.6.28 (`485090e7…`).
- v2.5.7's `python-build` manifest stops at 3.10.17 / 3.11.12 / 3.12.10. The Dockerfile pins 3.10.20 / 3.11.15 / 3.12.13, all postdating v2.5.7's recipe set, so `pyenv install 3.10.20` failed with `definition not found` on the first invocation.
- v2.6.28 (current latest stable pyenv tag) ships recipes for all three pinned patches.

### 2. Point PYTHONPATH at `<gmat_root>/bin`

- `PYTHONPATH=/opt/gmat/api` → `PYTHONPATH=/opt/gmat/bin`.
- `gmatpy` ships at `<gmat_root>/bin/gmatpy/` (with per-Python-version subpackages `_py310`/`_py311`/`_py312`/`_py313`/`_py314`), not under `api/`. `api/` carries the `load_gmat.py` / `BuildApiStartupFile.py` entry scripts, but the package itself lives in `bin/`.
- Verified against the upstream R2026a Linux install: `api/load_gmat.py` lines 13,19 put `<gmat_root>/bin` on `sys.path` before importing `gmatpy`; `BuildApiStartupFile.py` line 20 writes `api_startup_file.txt` into `bin/`.
- The original `api` path came from #60's spec, which was incorrect on this point.

## Test plan

Re-run on a clean Linux Docker host:

```bash
docker build --build-arg GMAT_VERSION=R2026a -t gmat:dev .

docker run --rm gmat:dev python3.10 -c 'import gmatpy; print(gmatpy)'
docker run --rm gmat:dev python3.11 -c 'import gmatpy; print(gmatpy)'
docker run --rm gmat:dev python3.12 -c 'import gmatpy; print(gmatpy)'
```

- [x] `docker build` exits 0 (already verified on Linux host)
- [x] `python3.10 -c 'import gmatpy'` exits 0
- [x] `python3.11 -c 'import gmatpy'` exits 0
- [x] `python3.12 -c 'import gmatpy'` exits 0

Stderr will likely include plugin-load warnings for `libMatlabInterface`, `libFminconOptimizer`, `libPythonInterface_py314`. Accepted noise — image ships stock GMAT.

Closes #71