### PR TITLE
Add PYTHON_VERSIONS build arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ FROM ubuntu:24.04 AS final
 ARG GMAT_VERSION
 ARG INSTALLER_SHA256=
 ARG ACTION_VERSION=
+ARG PYTHON_VERSIONS="3.12 3.11 3.10"
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYENV_ROOT=/opt/pyenv \
@@ -101,16 +102,32 @@ RUN git clone --no-checkout https://github.com/pyenv/pyenv.git "${PYENV_ROOT}" \
 
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 
-# 3.12 listed first so `python` / `python3` resolve to the newest minor;
-# `python3.10` and `python3.11` shims still resolve to their own installs.
-RUN pyenv install "${PYTHON_310_VERSION}" \
-    && pyenv install "${PYTHON_311_VERSION}" \
-    && pyenv install "${PYTHON_312_VERSION}" \
-    && pyenv global \
-        "${PYTHON_312_VERSION}" \
-        "${PYTHON_311_VERSION}" \
-        "${PYTHON_310_VERSION}" \
-    && pyenv rehash
+# Install only the Pythons listed in PYTHON_VERSIONS, in the order given.
+# `pyenv global` is set in the same order, so the first listed minor becomes
+# `python` / `python3`. Default `"3.12 3.11 3.10"` keeps 3.12 as the image's
+# default `python`. Single-Python builds (e.g. PYTHON_VERSIONS=3.11) yield a
+# slim image where only that interpreter is on PATH.
+RUN <<'EOF'
+set -eu
+if [ -z "$(echo "$PYTHON_VERSIONS" | tr -d '[:space:]')" ]; then
+    echo "PYTHON_VERSIONS is empty; specify at least one of: 3.10 3.11 3.12" >&2
+    exit 1
+fi
+patches=""
+for minor in $PYTHON_VERSIONS; do
+    case "$minor" in
+        3.10) patches="$patches $PYTHON_310_VERSION" ;;
+        3.11) patches="$patches $PYTHON_311_VERSION" ;;
+        3.12) patches="$patches $PYTHON_312_VERSION" ;;
+        *) echo "Unsupported PYTHON_VERSIONS entry '$minor'; supported: 3.10 3.11 3.12" >&2; exit 1 ;;
+    esac
+done
+for patch in $patches; do
+    pyenv install "$patch"
+done
+pyenv global $patches
+pyenv rehash
+EOF
 
 COPY --from=gmat-installer /staging/GMAT/${GMAT_VERSION} /opt/gmat
 


### PR DESCRIPTION
## Summary

Stage 2 of the Dockerfile now reads a `PYTHON_VERSIONS` build arg (default `"3.12 3.11 3.10"`) and installs only those Python minors via pyenv, in the order given. `pyenv global` is set in the same order, so the first listed minor becomes `python` / `python3`. Unsupported entries (anything outside `{3.10, 3.11, 3.12}`) and empty inputs fail the build before `pyenv install` runs.

The default value preserves prior behaviour: a plain `docker build` still installs all three Pythons with 3.12 as the default. The arg is the lever for:

- **Slim single-Python builds** for users who only need one interpreter (e.g. `--build-arg PYTHON_VERSIONS=3.11`).
- **Per-tag Python sets driven by the publish workflow** (#61), so the published `gmat:R2022a` tag can use `PYTHON_VERSIONS=3.10` (the only ABI gmatpy ships for R2022a in our pinned set), while R2025a and R2026a tags use the full default.

This sidesteps Option A's "broken interpreters in the R2022a image" footgun and Option B's per-version Dockerfile branching by giving the publish layer a clean, generic mechanism.

## Test plan

On a Linux Docker host:

```bash
# Default — all three Pythons, python -> 3.12
docker build --build-arg GMAT_VERSION=R2026a -t gmat:dev .
docker run --rm gmat:dev python --version            # 3.12.13
docker run --rm gmat:dev python3.10 -c 'import gmatpy'
docker run --rm gmat:dev python3.11 -c 'import gmatpy'
docker run --rm gmat:dev python3.12 -c 'import gmatpy'

# Slim single-Python (3.11 only)
docker build --build-arg GMAT_VERSION=R2026a --build-arg PYTHON_VERSIONS=3.11 -t gmat:dev-py311 .
docker run --rm gmat:dev-py311 python --version      # 3.11.15
docker run --rm gmat:dev-py311 python3.11 -c 'import gmatpy'
docker run --rm gmat:dev-py311 python3.10 --version  # exec: command not found (expected)

# R2022a slim build — only ABI gmatpy ships for R2022a
docker build --build-arg GMAT_VERSION=R2022a --build-arg PYTHON_VERSIONS=3.10 -t gmat:dev-r2022a .
docker run --rm gmat:dev-r2022a python --version     # 3.10.20
docker run --rm gmat:dev-r2022a python3.10 -c 'import gmatpy'

# Validation rejection
docker build --build-arg GMAT_VERSION=R2026a --build-arg PYTHON_VERSIONS=3.99 .   # fails before pyenv install
docker build --build-arg GMAT_VERSION=R2026a --build-arg PYTHON_VERSIONS="" .     # fails with empty-input message
```

- [x] Default build installs 3.10, 3.11, 3.12; `python` → 3.12; all three imports work
- [x] `PYTHON_VERSIONS=3.11` build installs only 3.11; `python` → 3.11
- [x] `PYTHON_VERSIONS=3.10` build with R2022a installs only 3.10; gmatpy imports
- [x] `PYTHON_VERSIONS=3.99` is rejected before `pyenv install`
- [x] Empty `PYTHON_VERSIONS` is rejected with a clear message

## Out of scope (per #73)

- Publish workflow wiring per-tag values — that's #61.
- Adding new Python minors (3.13, 3.14, …) — each new minor needs a Dockerfile patch-pin update.
- README / docs for the new arg — covered by the v0.3 docs tickets (#66/#67).
- Publishing single-Python image variants as separate tags.

Closes #73