### PR TITLE
GHCR publish workflow for GMAT base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,132 @@
+name: Publish image
+
+# Build and push the canonical GMAT base image (Dockerfile in repo root) to
+# ghcr.io/astro-tools/gmat for every supported GMAT version on each SemVer
+# release tag and on workflow_dispatch.
+#
+# Tag pattern is 'v*.*.*' (not 'v*') so the floating major-version alias `v0`
+# does not trigger a redundant republish each time it is re-pointed; only the
+# SemVer tags cut by semantic-release (#64) drive a publish.
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'GMAT version to build (matrix is filtered to this one)'
+        required: true
+        type: choice
+        options:
+          - R2022a
+          - R2025a
+          - R2026a
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/astro-tools/gmat
+  # Newest supported version. The matrix cell matching this also pushes the
+  # floating `latest` tag. Bump in lockstep when a new GMAT release is added
+  # to the action's supported set.
+  LATEST_GMAT_VERSION: R2026a
+
+jobs:
+  # Emit the version matrix dynamically: full set for tag pushes, single cell
+  # for workflow_dispatch. Done in a setup job because the `matrix` context is
+  # not available in job-level `if` expressions, so filtering cells inline is
+  # not possible.
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            versions='["${{ inputs.version }}"]'
+          else
+            versions='["R2022a","R2025a","R2026a"]'
+          fi
+          echo "value={\"version\":${versions}}" >> "$GITHUB_OUTPUT"
+          echo "Matrix: {\"version\":${versions}}"
+
+  publish:
+    name: publish (${{ matrix.version }})
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Job-level (not workflow-level) so the token's elevated `packages: write`
+    # is scoped only to where it is needed.
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Stream-hash the upstream installer to populate the gmat.installer-sha256
+      # OCI label and to give stage 1 of the Dockerfile something to verify
+      # against. The Dockerfile re-downloads in its own build context — if the
+      # SourceForge mirror serves a different blob between this step and the
+      # build, the build fails the SHA check loudly rather than silently
+      # publishing a mislabeled image.
+      - name: Compute installer SHA-256
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${{ matrix.version }}/gmat-ubuntu-x64-${{ matrix.version }}.tar.gz/download"
+          sha=$(curl --location --fail --silent --show-error \
+            --retry 5 --retry-all-errors "$url" \
+            | sha256sum | awk '{print $1}')
+          echo "Installer SHA-256: $sha"
+          echo "value=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Compute image tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          tags="${IMAGE}:${{ matrix.version }}"
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ matrix.version }}" = "${LATEST_GMAT_VERSION}" ]; then
+            tags="${tags},${IMAGE}:latest"
+          fi
+          echo "value=$tags" >> "$GITHUB_OUTPUT"
+          printf 'Tags:\n%s\n' "${tags//,/$'\n'}"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.value }}
+          build-args: |
+            GMAT_VERSION=${{ matrix.version }}
+            INSTALLER_SHA256=${{ steps.sha.outputs.value }}
+            ACTION_VERSION=${{ github.ref_name }}
+
+      # Print the labels of the just-pushed image so a release can be traced
+      # back to its installer SHA from the action log without pulling.
+      - name: Inspect image labels
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE}:${{ matrix.version }}" \
+            --format '{{ range $k, $v := .Image.Config.Labels }}{{ printf "%s=%s\n" $k $v }}{{ end }}' \
+            | grep -E '^(gmat\.|setup-gmat\.)'


### PR DESCRIPTION
## Summary

- New `.github/workflows/docker.yml` that builds the canonical `Dockerfile` per supported GMAT version (`R2022a`, `R2025a`, `R2026a`) on every SemVer release tag and on `workflow_dispatch`, pushing per-version tags to `ghcr.io/astro-tools/gmat`. The newest version's cell additionally pushes the floating `latest` tag — gated by a single `LATEST_GMAT_VERSION` env so the next supported-version bump is one line.
- Pre-step stream-hashes the upstream installer to populate the `gmat.installer-sha256` OCI label and to feed stage 1's SHA verification — if SourceForge serves a different blob between the pre-step and the build, the build fails the SHA check loud rather than publishing a mislabeled image.
- After push, an inspection step prints the `gmat.*` and `setup-gmat.*` labels from the registry manifest so a release can be traced back to its installer SHA from the action log alone.

## Notes

- Tag trigger is `'v*.*.*'` rather than the literal `'v*'` from the issue body, so the floating major-version alias `v0` does not trigger a redundant republish each time it is re-pointed. Only SemVer tags (which `semantic-release` will cut once #64 lands) drive a publish.
- `workflow_dispatch` is implemented via a `setup` job that emits a one-cell or three-cell matrix, because the `matrix` context is unavailable in job-level `if` expressions (caught by `actionlint`).

## Test plan

- [ ] `actionlint` passes locally (verified pre-push).
- [ ] `npm run format:check` clean (verified pre-push).
- [ ] First real validation requires either a `workflow_dispatch` against this branch (after the file is on `main`) or a tag cut. End-to-end behavior — GHCR auth, `--build-arg INSTALLER_SHA256` flow, label inspection output — cannot be exercised from a PR until merged.
- [ ] On first run, confirm: per-version tag pushed, `latest` tag moved only by `R2026a` cell, label inspection step prints all three required labels.

Closes #61