### PR TITLE
Smoke-test gmatpy import + propagation in Docker before publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,15 +111,79 @@ jobs:
           echo "value=$tags" >> "$GITHUB_OUTPUT"
           printf 'Tags:\n%s\n' "${tags//,/$'\n'}"
 
+      # Build into the runner's local docker daemon (load: true) under a
+      # throwaway tag so the smoke step below can `docker run` it before any
+      # registry interaction. The image is re-tagged and pushed only after
+      # smoke passes — see "Push to GHCR" below. Charter §4 v0.3 acceptance:
+      # "a non-zero exit blocks the release" (#62).
       - uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.tags.outputs.value }}
+          load: true
+          tags: gmat-smoke:${{ matrix.version }}
           build-args: |
             GMAT_VERSION=${{ matrix.version }}
             INSTALLER_SHA256=${{ steps.sha.outputs.value }}
             ACTION_VERSION=${{ github.ref_name }}
+
+      # Run the smoke script under each pinned Python (3.10 / 3.11 / 3.12)
+      # inside the locally-tagged image. Any failure propagates verbatim into
+      # the workflow log (no piping/grep) and aborts the cell via `set -e`,
+      # which prevents the push step below from running. Sample is the
+      # smallest .script in samples/ that exercises the propagator
+      # (Ex_HighFidelitySRP.script, 1269 B in R2026a) — see #62.
+      - name: Smoke (gmatpy import + stock-sample propagation per Python)
+        shell: bash
+        env:
+          # Wall-clock RunScript() duration is the elapsed-time metric: GMAT
+          # Spacecraft objects retain script-time config after RunScript
+          # (the propagated state lives in the runtime sandbox and isn't
+          # readable via GetObject), so probing sat.GetField('A1ModJulian')
+          # or 'X' would still return the initial values. Wall-clock is the
+          # robust signal: combined with LoadScript()/RunScript() returning
+          # True it proves gmatpy executed the propagator end-to-end.
+          SMOKE_PY: |
+            import sys, os, time
+            import gmatpy as gmat
+            gmat.Setup('/opt/gmat/bin/api_startup_file.txt')
+            os.chdir('/opt/gmat/samples')
+            if not gmat.LoadScript('Ex_HighFidelitySRP.script'):
+                sys.exit('LoadScript failed')
+            t0 = time.perf_counter()
+            if not gmat.RunScript():
+                sys.exit('RunScript failed')
+            elapsed = time.perf_counter() - t0
+            if elapsed <= 0:
+                sys.exit(f'No elapsed time: {elapsed}')
+            print(
+                f'OK py{sys.version_info.major}.{sys.version_info.minor}: '
+                f'gmatpy import + RunScript in {elapsed:.4f}s'
+            )
+        run: |
+          set -euo pipefail
+          image="gmat-smoke:${{ matrix.version }}"
+          for py in 3.10 3.11 3.12; do
+            echo "::group::Smoke (Python ${py})"
+            docker run --rm "$image" "python${py}" -c "$SMOKE_PY"
+            echo "::endgroup::"
+          done
+
+      # Re-tag the smoke-tested local image to its release tag(s) and push.
+      # Using `docker tag` + `docker push` (rather than a second
+      # build-push-action invocation) guarantees the published image is
+      # bit-identical to the image that just passed smoke.
+      - name: Push to GHCR
+        shell: bash
+        run: |
+          set -euo pipefail
+          src="gmat-smoke:${{ matrix.version }}"
+          IFS=',' read -r -a release_tags <<< "${{ steps.tags.outputs.value }}"
+          for tag in "${release_tags[@]}"; do
+            echo "::group::Push ${tag}"
+            docker tag "$src" "$tag"
+            docker push "$tag"
+            echo "::endgroup::"
+          done
 
       # Print the labels of the just-pushed image so a release can be traced
       # back to its installer SHA from the action log without pulling.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,29 +126,39 @@ jobs:
             INSTALLER_SHA256=${{ steps.sha.outputs.value }}
             ACTION_VERSION=${{ github.ref_name }}
 
-      # Run the smoke script under each pinned Python (3.10 / 3.11 / 3.12)
-      # inside the locally-tagged image. Any failure propagates verbatim into
-      # the workflow log (no piping/grep) and aborts the cell via `set -e`,
-      # which prevents the push step below from running. Sample is the
-      # smallest .script in samples/ that exercises the propagator
-      # (Ex_HighFidelitySRP.script, 1269 B in R2026a) — see #62.
-      - name: Smoke (gmatpy import + stock-sample propagation per Python)
+      # Run the smoke script under every Python the image supports for gmatpy
+      # — i.e. the intersection of (pyenv-installed interpreters) and
+      # (gmatpy/_pyXY directories shipped with this GMAT version). Per-version
+      # coverage varies: R2022a's Linux gmatpy ships only _py36..._py310 (per
+      # ci.yml self-test matrix), R2025a/R2026a ship _py312 universally and
+      # R2026a Linux additionally ships _py310/_py311. Detecting the
+      # intersection inside the container avoids hard-coding the matrix here
+      # and stays correct as future GMAT versions add or drop interpreters.
+      # Any failure propagates verbatim (no piping/grep) and aborts the cell
+      # via `set -e`, blocking the push step below. An empty intersection is
+      # itself a release-blocker — it means none of the installed Pythons can
+      # actually `import gmatpy` for this GMAT version. Sample is the smallest
+      # .script in samples/ that exercises the propagator: R2026a renamed it
+      # from Ex_R2014a_HighFidelitySRP.script to Ex_HighFidelitySRP.script,
+      # mirroring the SMOKE_SAMPLES map in src/smoke.ts. See #62.
+      - name: Smoke (gmatpy import + stock-sample propagation per supported Python)
         shell: bash
         env:
           # Wall-clock RunScript() duration is the elapsed-time metric: GMAT
-          # Spacecraft objects retain script-time config after RunScript
-          # (the propagated state lives in the runtime sandbox and isn't
-          # readable via GetObject), so probing sat.GetField('A1ModJulian')
-          # or 'X' would still return the initial values. Wall-clock is the
-          # robust signal: combined with LoadScript()/RunScript() returning
-          # True it proves gmatpy executed the propagator end-to-end.
+          # Spacecraft objects retain script-time config after RunScript (the
+          # propagated state lives in the runtime sandbox and isn't readable
+          # via GetObject), so probing sat.GetField('A1ModJulian') or 'X'
+          # would still return the initial values. Wall-clock is the robust
+          # signal: combined with LoadScript()/RunScript() returning True it
+          # proves gmatpy executed the propagator end-to-end.
           SMOKE_PY: |
             import sys, os, time
             import gmatpy as gmat
             gmat.Setup('/opt/gmat/bin/api_startup_file.txt')
             os.chdir('/opt/gmat/samples')
-            if not gmat.LoadScript('Ex_HighFidelitySRP.script'):
-                sys.exit('LoadScript failed')
+            sample = os.environ['SMOKE_SAMPLE']
+            if not gmat.LoadScript(sample):
+                sys.exit(f'LoadScript failed for {sample}')
             t0 = time.perf_counter()
             if not gmat.RunScript():
                 sys.exit('RunScript failed')
@@ -157,14 +167,36 @@ jobs:
                 sys.exit(f'No elapsed time: {elapsed}')
             print(
                 f'OK py{sys.version_info.major}.{sys.version_info.minor}: '
-                f'gmatpy import + RunScript in {elapsed:.4f}s'
+                f'gmatpy + {sample} in {elapsed:.4f}s'
             )
         run: |
           set -euo pipefail
           image="gmat-smoke:${{ matrix.version }}"
-          for py in 3.10 3.11 3.12; do
-            echo "::group::Smoke (Python ${py})"
-            docker run --rm "$image" "python${py}" -c "$SMOKE_PY"
+
+          case "${{ matrix.version }}" in
+            R2026a) sample="Ex_HighFidelitySRP.script" ;;
+            *)      sample="Ex_R2014a_HighFidelitySRP.script" ;;
+          esac
+
+          installed_pys=$(docker run --rm "$image" pyenv versions --bare \
+            | awk -F. 'NF>=2 {print $1"."$2}' | sort -u)
+          gmatpy_pys=$(docker run --rm "$image" sh -c 'ls -1 /opt/gmat/bin/gmatpy/' \
+            | awk '/^_py[0-9]+$/ {v=substr($0,4); print substr(v,1,1)"."substr(v,2)}' | sort -u)
+          to_smoke=$(comm -12 <(echo "$installed_pys") <(echo "$gmatpy_pys"))
+
+          if [ -z "$to_smoke" ]; then
+            echo "::error::No Python interpreter is both pyenv-installed AND supported by gmatpy in the ${{ matrix.version }} image"
+            echo "  pyenv installed: $(echo $installed_pys)"
+            echo "  gmatpy supports: $(echo $gmatpy_pys)"
+            exit 1
+          fi
+
+          echo "Smoking Python(s) for ${{ matrix.version }} (sample: ${sample}):" $(echo $to_smoke)
+          for py in $to_smoke; do
+            echo "::group::Smoke (Python ${py}, sample ${sample})"
+            docker run --rm \
+              -e SMOKE_SAMPLE="$sample" \
+              "$image" "python${py}" -c "$SMOKE_PY"
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## Summary

- Refactor `docker.yml` publish job: each matrix cell now builds the image into the runner's local docker daemon (`load: true`), runs a smoke script under every Python the image actually supports for `gmatpy`, and only re-tags + pushes to GHCR if all smokes pass. `set -e` ensures any one failure aborts the cell, so the push step never runs without a clean smoke.
- **Per-version sample**: R2022a/R2025a use `samples/Ex_R2014a_HighFidelitySRP.script`; R2026a uses `samples/Ex_HighFidelitySRP.script` (mirrors `src/smoke.ts:8-12`). Both are the smallest stock script that exercises the propagator in their release.
- **Per-version Python set**: detected at smoke time as the intersection of (pyenv-installed Pythons) ∩ (`gmatpy/_pyXY` directories shipped). R2022a → `{3.10}` (Linux ships `_py36`..`_py310` per `.github/workflows/ci.yml:68-77`); R2025a → `{3.12}`; R2026a → `{3.10, 3.11, 3.12}`. Future GMAT versions need no workflow edits — adding or dropping `_pyXY` wheels is reflected automatically. An empty intersection is itself a release-blocker.
- **Smoke metric**: wall-clock `RunScript()` duration, asserted non-zero. GMAT Spacecraft objects retain script-time configuration after `RunScript` (the propagated state lives in the runtime sandbox, unreadable via `GetObject`), so wall-clock is the only robust signal that propagation actually executed.
- **Push** uses `docker tag` + `docker push` against the smoke-tested local image, so the bytes published to GHCR are bit-identical to the bytes that just passed smoke.

## Test plan

- [ ] Trigger via `workflow_dispatch` once per supported version (`R2022a`, `R2025a`, `R2026a`) on this branch — confirm the smoke step discovers the expected Python set per version and pushes only after smoke passes. (Manual negative check: edit the smoke script to `sys.exit('boom')` and verify the cell fails red and the push step is skipped.)
- [ ] Verify `npm run all` is clean locally (passed pre-push).
- [ ] On the next release-tag publish, confirm smoke adds only ~1–3 min per matrix cell (no artifact transfer overhead — image stays in the runner's docker daemon).

Closes #62.