### PR TITLE
Sign published GHCR images with cosign keyless OIDC

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,10 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # Job-level (not workflow-level) so the token's elevated `packages: write`
-    # is scoped only to where it is needed.
+    # and the OIDC `id-token: write` (used by cosign keyless signing to
+    # exchange a workflow-issued token at Fulcio) are scoped only to where
+    # they are needed.
     permissions:
       contents: read
       packages: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -204,18 +207,72 @@ jobs:
       # Using `docker tag` + `docker push` (rather than a second
       # build-push-action invocation) guarantees the published image is
       # bit-identical to the image that just passed smoke.
+      #
+      # After each push we read the manifest digest from the registry via
+      # `docker buildx imagetools inspect` and emit `<repo>@sha256:<digest>`
+      # references on a step output. The next step signs by digest, not by
+      # tag — cosign's standard pattern, since signing the immutable manifest
+      # means a future re-push of the same tag against a different digest
+      # cannot inherit the signature. When `latest` shares a digest with the
+      # version tag (the LATEST_GMAT_VERSION cell), the dedup happens
+      # naturally below.
       - name: Push to GHCR
+        id: push
         shell: bash
         run: |
           set -euo pipefail
           src="gmat-smoke:${{ matrix.version }}"
           IFS=',' read -r -a release_tags <<< "${{ steps.tags.outputs.value }}"
+          declare -A digest_seen=()
+          digests=""
           for tag in "${release_tags[@]}"; do
             echo "::group::Push ${tag}"
             docker tag "$src" "$tag"
             docker push "$tag"
+            digest=$(docker buildx imagetools inspect "$tag" \
+              --format '{{.Manifest.Digest}}')
+            repo="${tag%:*}"
+            ref="${repo}@${digest}"
+            echo "Pushed ${tag} → ${ref}"
+            if [ -z "${digest_seen[$ref]:-}" ]; then
+              digest_seen[$ref]=1
+              digests="${digests}${ref}"$'\n'
+            fi
             echo "::endgroup::"
           done
+          {
+            echo 'digests<<EOF'
+            printf '%s' "$digests"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # Pin to v3 (current major) per the issue. cosign-installer puts
+      # `cosign` on PATH for subsequent steps in this job.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless OIDC signing: cosign exchanges the workflow's id-token for a
+      # short-lived Fulcio cert tied to this repo + workflow + ref, signs the
+      # image manifest, and uploads the signature as a sibling OCI artifact
+      # (no long-lived secrets). `--yes` skips the interactive Rekor prompt.
+      # Sequenced after smoke (earlier in this job) and after push, so a
+      # smoke or push failure aborts the job before any signature is issued.
+      - name: Sign images
+        shell: bash
+        env:
+          DIGESTS: ${{ steps.push.outputs.digests }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DIGESTS//[[:space:]]/}" ]; then
+            echo "::error::No digests captured from push step"
+            exit 1
+          fi
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            echo "::group::Sign ${ref}"
+            cosign sign --yes "$ref"
+            echo "::endgroup::"
+          done <<< "$DIGESTS"
 
       # Print the labels of the just-pushed image so a release can be traced
       # back to its installer SHA from the action log without pulling.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ For a workflow that also varies the GMAT version across the matrix, see the [mul
 
 Full documentation lives at **<https://astro-tools.github.io/setup-gmat/>** — getting started, inputs and outputs, recipes, FAQ, and troubleshooting.
 
+## Verifying images
+
+Every image published to `ghcr.io/astro-tools/gmat` is signed with [cosign](https://github.com/sigstore/cosign) using GitHub OIDC keyless signing. To verify provenance before pulling:
+
+```
+cosign verify ghcr.io/astro-tools/gmat:R2026a \
+  --certificate-identity-regexp 'https://github\.com/astro-tools/setup-gmat/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The signature is bound to the immutable manifest digest, so verifying a tag also pins you to the exact bytes that were signed. Substitute any supported `Rxxxxa` tag (or `latest`) for `R2026a`.
+
 ## Roadmap
 
 | Release          | Scope                                                                        |


### PR DESCRIPTION
## Summary

- `docker.yml` publish job gains `id-token: write` and a cosign keyless sign step. After each `docker push`, the manifest digest is read from the registry (`docker buildx imagetools inspect`) and `cosign sign --yes <repo>@sha256:...` runs via `sigstore/cosign-installer@v3`. Signing by digest (not by tag) pins the signature to immutable bytes; the version tag and `latest` (when they share a digest in the `LATEST_GMAT_VERSION` cell) get one signature that covers both refs.
- Smoke is sequenced before push and push before sign within the same job; `set -e` aborts before signing if either upstream step fails. The AC's `needs:` wording assumes smoke is a separate job — in this repo it's a step inside `publish`, so the dependency is enforced by step ordering rather than `needs:`. Refactoring smoke into a standalone job is bigger than this issue and worth its own ticket if you want it.
- README gains a "Verifying images" section with the literal `cosign verify` one-liner from the issue.

## Notes

- The verify regex in the one-liner (`https://github\.com/astro-tools/setup-gmat/.*`) matches any workflow in this repo. A tighter form anchors on the workflow file path (`…/.github/workflows/docker\.yml@.*`). Kept the issue's literal form here; happy to tighten if you'd prefer.
- End-to-end signing cannot be exercised pre-merge — keyless signing requires a real GitHub Actions OIDC token, which is only issued during a tag push or `workflow_dispatch` run. Recommend a one-off `workflow_dispatch` against `R2026a` after merge to confirm cosign verify works against the first signed image.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` produces no `dist/` drift
- [ ] Post-merge: tag a release (or run `workflow_dispatch` on `R2026a`) and confirm the `Sign images` step succeeds against each pushed digest
- [ ] Post-merge: run the README's `cosign verify` one-liner against the first signed image and confirm it passes

Closes #63