### PR TITLE
docs: mirror remaining recipes as runnable example workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Runnable workflow files live in [`examples/`](examples/) — one per recipe, rea
 - [`examples/multi-version.yml`](examples/multi-version.yml) — `{ubuntu, windows, macos} × {R2022a, R2025a, R2026a}` matrix.
 - [`examples/docker-mode.yml`](examples/docker-mode.yml) — run the job inside `ghcr.io/astro-tools/gmat:Rxxxxa` instead of using the action.
 
-The files live under `examples/` rather than `.github/workflows/` so GitHub does not auto-run them in this repo. Each one mirrors the corresponding [recipe page](https://astro-tools.github.io/setup-gmat/recipes/) in the docs.
+Each one mirrors the corresponding [recipe page](https://astro-tools.github.io/setup-gmat/recipes/) in the docs.
 
 ## Verifying images
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ For a workflow that also varies the GMAT version across the matrix, see the [mul
 
 Full documentation lives at **<https://astro-tools.github.io/setup-gmat/>** — getting started, inputs and outputs, recipes, FAQ, and troubleshooting.
 
+## Examples
+
+Runnable workflow files live in [`examples/`](examples/) — one per recipe, ready to drop into a downstream repo's `.github/workflows/` verbatim:
+
+- [`examples/pytest.yml`](examples/pytest.yml) — run a `pytest` suite that imports `gmatpy`.
+- [`examples/run-mission-script.yml`](examples/run-mission-script.yml) — drive a `.script` mission file from Python and upload the report.
+- [`examples/skip-on-docs.yml`](examples/skip-on-docs.yml) — `paths-ignore` so docs-only PRs skip the heavy install.
+- [`examples/multi-version.yml`](examples/multi-version.yml) — `{ubuntu, windows, macos} × {R2022a, R2025a, R2026a}` matrix.
+- [`examples/docker-mode.yml`](examples/docker-mode.yml) — run the job inside `ghcr.io/astro-tools/gmat:Rxxxxa` instead of using the action.
+
+The files live under `examples/` rather than `.github/workflows/` so GitHub does not auto-run them in this repo. Each one mirrors the corresponding [recipe page](https://astro-tools.github.io/setup-gmat/recipes/) in the docs.
+
 ## Verifying images
 
 Every image published to `ghcr.io/astro-tools/gmat` is signed with [cosign](https://github.com/sigstore/cosign) using GitHub OIDC keyless signing. To verify provenance before pulling:

--- a/docs/recipes/docker.md
+++ b/docs/recipes/docker.md
@@ -1,5 +1,7 @@
 # Run jobs in the GMAT container image
 
+Runnable copy: [`examples/docker-mode.yml`](https://github.com/astro-tools/setup-gmat/blob/v0/examples/docker-mode.yml)
+
 A workflow that runs its job inside `ghcr.io/astro-tools/gmat:R2026a` instead of installing GMAT on a fresh runner. The image ships GMAT pre-installed with `gmatpy` already importable, so the job skips the `setup-gmat` step entirely.
 
 Reach for this shape over the action when you want any of:

--- a/docs/recipes/multi-version.md
+++ b/docs/recipes/multi-version.md
@@ -1,5 +1,7 @@
 # Validate against every GMAT version on every OS
 
+Runnable copy: [`examples/multi-version.yml`](https://github.com/astro-tools/setup-gmat/blob/v0/examples/multi-version.yml)
+
 A workflow that exercises a consumer project against `{ubuntu-latest, windows-latest, macos-latest} × {R2022a, R2025a, R2026a}` — the full nine-combo matrix `setup-gmat` supports, minus one unsupported pair.
 
 The matrix surfaces version- and platform-specific breakage early: a fix that works on Linux R2026a but regresses on Windows R2022a fails one cell instead of slipping through.

--- a/docs/recipes/pytest.md
+++ b/docs/recipes/pytest.md
@@ -1,5 +1,7 @@
 # Run pytest against gmatpy
 
+Runnable copy: [`examples/pytest.yml`](https://github.com/astro-tools/setup-gmat/blob/v0/examples/pytest.yml)
+
 A workflow that installs GMAT, then runs a `pytest` suite whose tests `import gmatpy`. The test step sets `PYTHONPATH=$GMAT_ROOT/bin` so `gmatpy` resolves on import — see [Getting started → Calling gmatpy from your own steps](../getting-started.md#calling-gmatpy-from-your-own-steps) for why this is necessary.
 
 ## Workflow

--- a/docs/recipes/run-mission-script.md
+++ b/docs/recipes/run-mission-script.md
@@ -1,5 +1,7 @@
 # Run a mission script and upload its report
 
+Runnable copy: [`examples/run-mission-script.yml`](https://github.com/astro-tools/setup-gmat/blob/v0/examples/run-mission-script.yml)
+
 A workflow that installs GMAT, runs a `.script` mission file via `gmatpy.LoadScript` / `RunScript` from a small Python driver, then uploads the resulting report directory as a build artifact.
 
 The example uses the stock `samples/Ex_HighFidelitySRP.script` shipped inside the GMAT install, so the recipe runs as-is without any user-supplied script. Substitute your own `.script` path for real mission analysis.

--- a/docs/recipes/skip-on-docs.md
+++ b/docs/recipes/skip-on-docs.md
@@ -1,5 +1,7 @@
 # Skip the GMAT install on docs-only changes
 
+Runnable copy: [`examples/skip-on-docs.yml`](https://github.com/astro-tools/setup-gmat/blob/v0/examples/skip-on-docs.yml)
+
 Installing GMAT R2026a is a multi-hundred-megabyte download and a few minutes of CI time. Skipping the install on docs-only changes (READMEs, MkDocs pages, design notes) keeps PRs cheap when no code is touched.
 
 The fix is GitHub's built-in `paths-ignore` filter on the workflow trigger.

--- a/examples/multi-version.yml
+++ b/examples/multi-version.yml
@@ -1,0 +1,38 @@
+# Companion to docs/recipes/multi-version.md — exercises a consumer project
+# against {ubuntu, windows, macos} × {R2022a, R2025a, R2026a} minus the
+# unsupported macos × R2022a cell. fail-fast: false keeps every cell running
+# even when one fails, so a regression in one (os, version) pair doesn't
+# cancel signal from the others.
+
+name: gmat-compat
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        version: [R2022a, R2025a, R2026a]
+        exclude:
+          # macOS R2022a ships an x86_64-only DMG that Apple Silicon
+          # runners cannot dlopen — see Inputs and outputs.
+          - os: macos-latest
+            version: R2022a
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: ${{ matrix.version }}
+
+      - name: Run tests
+        run: pytest tests/ -v
+        env:
+          PYTHONPATH: ${{ env.GMAT_ROOT }}/bin

--- a/examples/pytest.yml
+++ b/examples/pytest.yml
@@ -1,0 +1,29 @@
+# Companion to docs/recipes/pytest.md — installs GMAT, then runs a pytest
+# suite whose tests `import gmatpy`. The test step sets PYTHONPATH so gmatpy
+# resolves on import; the action does not modify PYTHONPATH by design.
+
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: R2026a
+
+      - name: Install test dependencies
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/ -v
+        env:
+          PYTHONPATH: ${{ env.GMAT_ROOT }}/bin

--- a/examples/run-mission-script.yml
+++ b/examples/run-mission-script.yml
@@ -1,0 +1,35 @@
+# Companion to docs/recipes/run-mission-script.md — installs GMAT, runs a
+# .script mission file via gmatpy.LoadScript / RunScript from a small Python
+# driver, then uploads the resulting report directory as a build artifact.
+#
+# Expects a `run_mission.py` driver in the consumer repo — see the recipe
+# page for the reference driver that loads $GMAT_ROOT/samples/Ex_HighFidelitySRP.script.
+
+name: run-mission
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: R2026a
+
+      - name: Run mission script
+        run: python run_mission.py
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mission-reports
+          path: reports/
+          if-no-files-found: error

--- a/examples/skip-on-docs.yml
+++ b/examples/skip-on-docs.yml
@@ -1,0 +1,30 @@
+# Companion to docs/recipes/skip-on-docs.md — uses paths-ignore on the
+# trigger so PRs that only touch READMEs or docs/ skip the multi-hundred-MB
+# GMAT install entirely. See the recipe for the inverse `paths` filter that
+# scopes a separate docs build to the same files.
+
+name: gmat-ci
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: R2026a
+      # ... your test / propagation steps


### PR DESCRIPTION
## Summary
- Adds `examples/{pytest,run-mission-script,skip-on-docs,multi-version}.yml` — runnable workflow files extracted verbatim from each recipe page, matching the header-comment + raw-YAML convention set by `examples/docker-mode.yml` (#78). Files live under `examples/` rather than `.github/workflows/` so GitHub does not auto-run them in this repo.
- Adds a one-line "Runnable copy:" link at the top of all five recipe pages (`pytest.md`, `run-mission-script.md`, `skip-on-docs.md`, `multi-version.md`, `docker.md`) pointing at the corresponding `examples/*.yml` on the `v0` branch. `docker.md` is included because #78 didn't backfill it; the convention applies uniformly going forward.
- Adds an "Examples" subsection to the README between "Documentation" and "Verifying images" listing each runnable example with a one-line summary.

## Test plan
- [x] CI green on the branch.
- [x] Each `examples/*.yml` parses as valid workflow YAML (verified locally with `yaml.safe_load`).
- [x] Each "Runnable copy" link resolves once the branch lands on `v0` (the `blob/v0/...` URLs are intentionally pinned to the major branch, not `main`).
- [x] README "Examples" section renders cleanly on github.com and links into `examples/`.

Closes #67