### PR TITLE
Marketplace listing pass for v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # setup-gmat
 
-GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General Mission Analysis Tool) and bootstrapping `gmatpy` in CI.
+GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General Mission Analysis Tool) on Linux, Windows, and macOS runners, with `gmatpy` bootstrapped for use in CI.
 
 ```yaml
 - uses: actions/setup-python@v5
@@ -11,6 +11,8 @@ GitHub Action for installing [NASA GMAT](https://gmat.gsfc.nasa.gov/) (General M
     version: R2026a
     cache: true
 ```
+
+> **Want the container instead of the action?** A canonical GMAT image is published at [`ghcr.io/astro-tools/gmat`](https://github.com/astro-tools/setup-gmat/pkgs/container/gmat) — see [Verifying images](#verifying-images) below.
 
 ## Status
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup GMAT'
-description: 'Install NASA GMAT and bootstrap gmatpy for use in CI.'
+description: 'Install NASA GMAT (R2022a/R2025a/R2026a) on Linux, Windows, and macOS, with gmatpy bootstrap for CI.'
 author: 'astro-tools'
 
 branding:


### PR DESCRIPTION
## Summary

- `action.yml` `description` rewritten to mention cross-platform + multi-version (`R2022a/R2025a/R2026a` × Linux/Windows/macOS); 100 chars, well under the 125-char Marketplace cap.
- `branding.icon: cpu` and `branding.color: blue` re-verified against the current GitHub Actions allow-lists — both still valid, no change.
- README tagline updated to mention Linux/Windows/macOS up front.
- New one-line hero callout pointing image consumers at `ghcr.io/astro-tools/gmat` (audience is partly disjoint from action consumers).
- Existing `## Supported versions` table already lists `R2022a`/`R2025a`/`R2026a` correctly — no change.
- Community profile is already at `health_percentage: 100` (`gh api repos/astro-tools/setup-gmat/community/profile`). The only `null` field is `issue_template`, but `.github/ISSUE_TEMPLATE/` exists in-repo — directory-based templates aren't reflected in that legacy API field. Nothing reasonable to close.

This lands the metadata ahead of the v0.3.0 release cut so the Marketplace listing auto-refresh on release publish picks up the new copy.

## Test plan

- [ ] CI green on this branch.
- [ ] After v0.3.0 ships, spot-check the Marketplace listing renders the new `description` and tagline.

Closes #68