### PR TITLE
chore: cut v0.3.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ name: Publish image
 #
 # Tag pattern is 'v*.*.*' (not 'v*') so the floating major-version alias `v0`
 # does not trigger a redundant republish each time it is re-pointed; only the
-# SemVer tags cut by semantic-release (#64) drive a publish.
+# immutable SemVer tags pushed by the manual release-cut process drive a publish.
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to setup-gmat are documented here. The format follows [Keep 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-02
+
+Canonical GMAT base image published on GHCR, with cosign keyless signing and a per-image gmatpy smoke gate before publish. Container-mode adoption is now a first-class recipe alongside the action.
+
+### Added
+
+- Multi-stage `Dockerfile` for the canonical GMAT base image: ubuntu:24.04 base, pyenv-managed Python 3.10/3.11/3.12, GMAT installed and `BuildApiStartupFile.py` resolved at build time, `GMAT_ROOT` and `PYTHONPATH` set so `import gmatpy` works in any of the three Pythons (#70, #72).
+- `PYTHON_VERSIONS` build arg on the Dockerfile so downstream image builds can narrow the bundled Python set without forking the Dockerfile (#74).
+- `docker.yml` GHCR publish workflow: builds the canonical image for every supported GMAT version on each `v*.*.*` tag, pushes per-version tags (`R2022a`, `R2025a`, `R2026a`) plus a `latest` alias floating to the newest supported release (#75).
+- Per-image smoke gate that runs `import gmatpy` and a one-line propagation against each bundled Python before push, failing the workflow before any tag is published if the import or run regresses (#76).
+- Cosign keyless signing for every pushed digest via GitHub OIDC, with the verification one-liner documented in the README (#77).
+- Container-mode docs recipe (`docs/recipes/docker.md`) and runnable `examples/docker-mode.yml`: how to run a job inside `ghcr.io/astro-tools/gmat:Rxxxxa` instead of installing the action on a fresh runner (#78).
+- Runnable workflow files in `examples/` mirroring the remaining recipe pages (`pytest.yml`, `run-mission-script.yml`, `skip-on-docs.yml`, `multi-version.yml`) so downstream repos can copy a complete `.github/workflows/*.yml` verbatim (#79).
+- Marketplace listing pass for v0.3: branding, description, and inputs/outputs metadata refreshed (#80).
+
 ## [0.2.0] - 2026-05-01
 
 Cross-platform coverage and full version matrix. setup-gmat now installs GMAT on Linux, Windows, and macOS runners against R2022a, R2025a, or R2026a — every cell of that matrix exercised in self-CI on every PR and on a weekly cron.
@@ -26,6 +41,8 @@ Cross-platform coverage and full version matrix. setup-gmat now installs GMAT on
 
 - v0.1's R2026a-hardcoded assumptions removed: cache key, smoke check, and version-resolution logic are now driven by the validated `version` input rather than embedded R2026a constants (audit folded into #47).
 - v0.1's Linux-hardcoded assumptions removed: `download` / `extract` / `GMAT_ROOT` resolution moved behind a per-OS dispatch instead of a single Linux tarball path (audit folded into #48).
+
+## [0.1.0] - 2026-04-30
 
 First usable release. Installs GMAT R2026a on Ubuntu runners and bootstraps gmatpy for use in CI.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ The signature is bound to the immutable manifest digest, so verifying a tag also
 
 | Release          | Scope                                                                                            |
 | ---------------- | ------------------------------------------------------------------------------------------------ |
-| v0.2             | Linux + Windows + macOS, R2022a/R2025a/R2026a, caching, smoke check.                             |
 | v0.3 _(current)_ | Canonical GMAT image on GHCR, cosign keyless signing, container-mode recipe + runnable examples. |
 | v1.0             | Public API stability; at least two external consumers shipped on the action.                     |
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ The signature is bound to the immutable manifest digest, so verifying a tag also
 
 ## Roadmap
 
-| Release          | Scope                                                                        |
-| ---------------- | ---------------------------------------------------------------------------- |
-| v0.2 _(current)_ | Linux + Windows + macOS, R2022a/R2025a/R2026a, caching, smoke check.         |
-| v0.3             | Docker image on GHCR, semantic-release wired up, cosign image signing.       |
-| v1.0             | Public API stability; at least two external consumers shipped on the action. |
+| Release          | Scope                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| v0.2             | Linux + Windows + macOS, R2022a/R2025a/R2026a, caching, smoke check.                             |
+| v0.3 _(current)_ | Canonical GMAT image on GHCR, cosign keyless signing, container-mode recipe + runnable examples. |
+| v1.0             | Public API stability; at least two external consumers shipped on the action.                     |
 
 ## License
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,8 +64,8 @@ See [Getting started → Calling gmatpy from your own steps](getting-started.md#
 
 The action is built around the `@actions/*` toolkit and assumes a runner-like environment (`RUNNER_TEMP`, `GITHUB_ENV`, `actions/cache`). It is not designed for direct local invocation.
 
-For local use, install GMAT directly from [SourceForge](https://sourceforge.net/projects/gmat/) and run `BuildApiStartupFile.py` against it manually. A canonical Docker image on GHCR is planned for **v0.3** but is not yet published.
+For local use, either install GMAT directly from [SourceForge](https://sourceforge.net/projects/gmat/) and run `BuildApiStartupFile.py` against it manually, or pull the canonical image from [`ghcr.io/astro-tools/gmat`](https://github.com/astro-tools/setup-gmat/pkgs/container/gmat) — it ships GMAT pre-installed with `gmatpy` importable from Python 3.10/3.11/3.12, so `docker run --rm ghcr.io/astro-tools/gmat:R2026a python -c 'import gmatpy'` works out of the box.
 
 ## Does setup-gmat verify the download?
 
-It checks the archive size against a hardcoded per-version minimum (e.g. ≈380 MiB for R2026a) before extraction, which catches truncated downloads and SourceForge HTML-mirror responses. It does **not** verify a checksum or signature — supply-chain hardening (cosign-signed Docker image, attested provenance) is on the v0.3 roadmap.
+It checks the archive size against a hardcoded per-version minimum (e.g. ≈380 MiB for R2026a) before extraction, which catches truncated downloads and SourceForge HTML-mirror responses. It does **not** verify an installer checksum or signature against the SourceForge download — there is no upstream-published checksum to compare against. The canonical Docker image is a separate trust path: every published `ghcr.io/astro-tools/gmat:Rxxxxa` digest is signed via cosign keyless OIDC and verifiable with the one-liner in the README. Attested SLSA provenance for the image is the remaining supply-chain item and is not yet wired up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-gmat",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-gmat",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-gmat",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "GitHub Action to install NASA GMAT (General Mission Analysis Tool) and bootstrap gmatpy in CI.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `package.json` + lockfile to `0.3.0` and aggregates the `[0.3.0]` CHANGELOG section over PRs #70, #72, #74, #75, #76, #77, #78, #79, #80 (Docker base image, GHCR publish, smoke gate, cosign signing, container recipe + examples, Marketplace pass).
- Backfills the missing `## [0.1.0] - 2026-04-30` CHANGELOG header that the v0.2 cut left orphaned, moves the README roadmap `_(current)_` marker to v0.3, and rewrites the v0.3 row to reflect what actually shipped (semantic-release deferred per #64).
- Flips the two `docs/faq.md` paragraphs that still described the GHCR image and cosign signing as planned, and drops the stale "cut by semantic-release" comment in `docker.yml`.

No source / `dist/` changes — `npm run all` is a no-op rebuild.

## Test plan

- [x] `npm run all` (format check, lint, typecheck, build) passes; `dist/` does not change.
- [x] `git log v0.2.0..main` PR list cross-checked against the new CHANGELOG section — all 9 PRs covered.
- [x] CI green on PR.
- [ ] On merge: tag `v0.3.0` (annotated) from the merge commit, force-retag floating `v0` to the same SHA, push both. The `v0.3.0` push fires `docker.yml` (publishes + signs `R2022a`/`R2025a`/`R2026a`/`latest`) and `docs.yml`.
- [ ] Post-publish: `cosign verify ghcr.io/astro-tools/gmat:R2026a ...` against the live image with the README one-liner.
- [ ] Draft GitHub Release for `v0.3.0` from the new CHANGELOG section, tick the Marketplace publish checkbox.
- [ ] Post release announcement in `astro-tools/.github` Discussions → Announcements.
- [ ] Open the gmat-run CI migration PR (#16).

Closes #69
